### PR TITLE
Added `seeResponseIsValidOnJsonSchema`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": ">=5.6.0 <8.0",
         "flow/jsonpath": "^0.5",
-        "codeception/codeception": "^4.0"
+        "codeception/codeception": "^4.0",
+        "justinrainbow/json-schema": "^5.2.9"
     },
     "require-dev": {
         "codeception/util-robohelpers": "dev-master",

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -773,18 +773,7 @@ EOF;
     {
         $responseContent = $this->connectionModule->_getResponseContent();
         \PHPUnit\Framework\Assert::assertNotEquals('', $responseContent, 'response is empty');
-        json_decode($responseContent);
-        $errorCode = json_last_error();
-        $errorMessage = json_last_error_msg();
-        \PHPUnit\Framework\Assert::assertEquals(
-            JSON_ERROR_NONE,
-            $errorCode,
-            sprintf(
-                "Invalid json: %s. System message: %s.",
-                $responseContent,
-                $errorMessage
-            )
-        );
+        $this->decodeAndValidateJson($responseContent);
     }
 
     /**
@@ -853,32 +842,10 @@ EOF;
     {
         $responseContent = $this->connectionModule->_getResponseContent();
         \PHPUnit\Framework\Assert::assertNotEquals('', $responseContent, 'response is empty');
-        $responseObject = json_decode($responseContent);
-        $errorCode = json_last_error();
-        $errorMessage = json_last_error_msg();
-        \PHPUnit\Framework\Assert::assertEquals(
-            JSON_ERROR_NONE,
-            $errorCode,
-            sprintf(
-                "Invalid json: %s. System message: %s.",
-                $responseContent,
-                $errorMessage
-            )
-        );
+        $responseObject = $this->decodeAndValidateJson($responseContent);
 
         \PHPUnit\Framework\Assert::assertNotEquals('', $schema, 'schema is empty');
-        $schemaObject = json_decode($schema, true);
-        $errorCode = json_last_error();
-        $errorMessage = json_last_error_msg();
-        \PHPUnit\Framework\Assert::assertEquals(
-            JSON_ERROR_NONE,
-            $errorCode,
-            sprintf(
-                "Invalid schema json: %s. System message: %s.",
-                $responseContent,
-                $errorMessage
-            )
-        );
+        $schemaObject = $this->decodeAndValidateJson($schema, "Invalid schema json: %s. System message: %s.");
 
         $validator = new JsonSchemaValidator();
         $validator->validate($responseObject, $schemaObject, JsonContraint::CHECK_MODE_VALIDATE_SCHEMA);
@@ -892,6 +859,29 @@ EOF;
             $outcome,
             $error
         );
+    }
+
+    /**
+     * Converts string to json and asserts that no error occured while decoding.
+     *
+     * @param string $jsonString the json encoded string
+     * @param string $errorFormat optional string for custom sprintf format
+     */
+    protected function decodeAndValidateJson($jsonString, $errorFormat="Invalid json: %s. System message: %s.")
+    {
+        $json = json_decode($jsonString);
+        $errorCode = json_last_error();
+        $errorMessage = json_last_error_msg();
+        \PHPUnit\Framework\Assert::assertEquals(
+            JSON_ERROR_NONE,
+            $errorCode,
+            sprintf(
+                $errorFormat,
+                $jsonString,
+                $errorMessage
+            )
+        );
+        return $json;
     }
 
     /**

--- a/tests/data/responses/invalid-basic-schema.json
+++ b/tests/data/responses/invalid-basic-schema.json
@@ -1,0 +1,5 @@
+{
+  "firstName": "John",
+  "lastName": "Doe",
+  "age": -10
+}

--- a/tests/data/responses/invalid-complex-schema.json
+++ b/tests/data/responses/invalid-complex-schema.json
@@ -1,0 +1,13 @@
+{
+  "fruits": [ "apple", "orange", "pear" ],
+  "vegetables": [
+    {
+      "veggieName": "potato",
+      "veggieLike": true
+    },
+    {
+      "veggieName": "broccoli",
+      "veggieLike": "false"
+    }
+  ]
+}

--- a/tests/data/responses/valid-basic-schema.json
+++ b/tests/data/responses/valid-basic-schema.json
@@ -1,0 +1,5 @@
+{
+  "firstName": "John",
+  "lastName": "Doe",
+  "age": 21
+}

--- a/tests/data/responses/valid-complex-schema.json
+++ b/tests/data/responses/valid-complex-schema.json
@@ -1,0 +1,13 @@
+{
+  "fruits": [ "apple", "orange", "pear" ],
+  "vegetables": [
+    {
+      "veggieName": "potato",
+      "veggieLike": true
+    },
+    {
+      "veggieName": "broccoli",
+      "veggieLike": false
+    }
+  ]
+}

--- a/tests/data/schemas/basic-schema.json
+++ b/tests/data/schemas/basic-schema.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string",
+      "description": "The person's first name."
+    },
+    "lastName": {
+      "type": "string",
+      "description": "The person's last name."
+    },
+    "age": {
+      "description": "Age in years which must be equal to or greater than zero.",
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/tests/data/schemas/complex-schema.json
+++ b/tests/data/schemas/complex-schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://example.com/arrays.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A representation of a person, company, organization, or place",
+  "type": "object",
+  "properties": {
+    "fruits": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "vegetables": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/veggie" }
+    }
+  },
+  "definitions": {
+    "veggie": {
+      "type": "object",
+      "required": [ "veggieName", "veggieLike" ],
+      "properties": {
+        "veggieName": {
+          "type": "string",
+          "description": "The name of the vegetable."
+        },
+        "veggieLike": {
+          "type": "boolean",
+          "description": "Do I like this vegetable?"
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -443,6 +443,29 @@ class RestTest extends Unit
     }
 
     /**
+     * @param $schema
+     * @param $response
+     * @param $outcome
+     * @param $error
+     *
+     * @dataProvider schemaAndResponse
+     */
+
+    public function testSeeResponseIsValidOnJsonSchemachesJsonSchema($schema, $response, $outcome, $error) {
+
+        $response = file_get_contents(codecept_data_dir($response));
+        $this->setStubResponse($response);
+
+        $validSchema = file_get_contents(codecept_data_dir($schema));
+
+        if (!$outcome) {
+            $this->expectExceptionMessage($error);
+            $this->shouldFail();
+        }
+        $this->module->seeResponseIsValidOnJsonSchema($validSchema);
+    }
+
+    /**
      * @param $configUrl
      * @param $requestUrl
      * @param $expectedFullUrl
@@ -479,6 +502,17 @@ class RestTest extends Unit
         $module->_before(Stub::makeEmpty('\Codeception\Test\Test'));
 
         $module->sendGET($requestUrl);
+    }
+
+    public static function schemaAndResponse()
+    {
+        return [
+            //schema, responsefile, valid
+            ['schemas/basic-schema.json', 'responses/valid-basic-schema.json', true, ""],
+            ['schemas/basic-schema.json', 'responses/invalid-basic-schema.json', false, "Must have a minimum value of 0"],
+            ['schemas/complex-schema.json', 'responses/valid-complex-schema.json', true, ""],
+            ['schemas/complex-schema.json', 'responses/invalid-complex-schema.json', false, "String value found, but a boolean is required"]
+        ];
     }
 
     public static function configAndRequestUrls()


### PR DESCRIPTION
Implemented `seeResponseIsValidOnJsonSchema`
It accepts a valid json schema as string and will test the response against this schema.

Resolves https://github.com/Codeception/Codeception/issues/2472