### PR TITLE
add a way to set or clean server parameters

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1508,4 +1508,29 @@ EOF;
     {
         $this->client->followRedirects(true);
     }
+    
+    /**
+     * Sets SERVER parameters valid for all next requests.
+     * this will remove old ones.
+     * 
+     * ```php
+     * $I->setServerParameters([]);
+     * ```
+     */
+    public function setServerParameters(array $params)
+    {
+        $this->client->setServerParameters($params);
+    }
+    
+    /**
+     * Sets SERVER parameter valid for all next requests.
+     * 
+     * ```php
+     * $I->haveServerParameter('name', 'value');
+     * ```
+     */
+    public function haveServerParameter($name, $value)
+    {
+        $this->client->setServerParameter($name, $value);
+    }
 }

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -442,6 +442,28 @@ class RestTest extends Unit
         $this->module->amDigestAuthenticated('username', 'password');
     }
 
+    public function testCanResetHTTPAuthenticated()
+    {
+        $this->module->amHttpAuthenticated('user', 'pass');
+        $this->module->sendGET('/rest/user/');
+        $server = $this->module->client->getRequest()->getServer();
+        $this->assertArrayHasKey('PHP_AUTH_USER', $server);
+        $this->assertArrayHasKey('PHP_AUTH_PW', $server);
+        $this->module->setServerParameters([]);
+        $this->module->sendGET('/rest/user/');
+        $server = $this->module->client->getRequest()->getServer();
+        $this->assertArrayNotHasKey('PHP_AUTH_USER', $server);
+        $this->assertArrayNotHasKey('PHP_AUTH_PW', $server);
+    }
+
+    public function testHaveServerParameter()
+    {
+        $this->module->haveServerParameter('my', 'param');
+        $this->module->sendGET('/rest/user/');
+        $server = $this->module->client->getRequest()->getServer();
+        $this->assertArrayHasKey('my', $server);
+    }
+
     /**
      * @param $configUrl
      * @param $requestUrl


### PR DESCRIPTION
```php
public function loginWithCredentials(string $usernameOrEmail, string $password)
{
    $I = $this;
    ​
    $I->amHttpAuthenticated('android', '');
    $I->sendPOST('/oauth2/token', [
        'username' => $usernameOrEmail,
        'password' => $password,
        'grant_type' => 'password',
    ]);
    $accessToken = $I->grabDataFromResponseByJsonPath('$.access_token');
    // I would like to remove HTTP auth here but there is no way how to do it now
    // but now I will be able to reset server params with $I->setServerParameters([]);
    $I->amBearerAuthenticated($accessToken[0]);
    $I->sendPOST('/user-profile');
}
```