### PR TITLE
Added examples

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -841,7 +841,7 @@ EOF;
      * ``` php
      * <?php
      * // response: {"name": "john", "age": 20}
-     * $I->seeResponseIsValidOnJsonSchema('{"type": "object"}');
+     * $I->seeResponseIsValidOnJsonSchemaString('{"type": "object"}');
      *
      * // response {"name": "john", "age": 20}
      * $schema = [
@@ -852,7 +852,7 @@ EOF;
      *      ]
      *  ]
      * ];
-     * $I->seeResponseIsValidOnJsonSchema(json_encode($schema));
+     * $I->seeResponseIsValidOnJsonSchemaString(json_encode($schema));
      *
      * ?>
      * ```
@@ -860,7 +860,7 @@ EOF;
      * @param string $schema
      * @part json
      */
-    public function seeResponseIsValidOnJsonSchema($schema)
+    public function seeResponseIsValidOnJsonSchemaString($schema)
     {
         $responseContent = $this->connectionModule->_getResponseContent();
         \PHPUnit\Framework\Assert::assertNotEquals('', $responseContent, 'response is empty');
@@ -881,6 +881,24 @@ EOF;
             $outcome,
             $error
         );
+    }
+
+    /**
+     * Checks whether last response matches the supplied json schema (https://json-schema.org/)
+     * Supply schema as filepath in your codeception data directory.
+     *
+     * @see codecept_data_dir()
+     *
+     * @param string $schemaFilename
+     * @part json
+     */
+    public function seeResponseIsValidOnJsonSchema($schemaFilename)
+    {
+        $file = codecept_data_dir() . $schemaFilename;
+        if (!file_exists($file)) {
+            throw new ModuleException(__CLASS__, "File $file does not exist");
+        }
+        $this->seeResponseIsValidOnJsonSchemaString(file_get_contents($file));
     }
 
     /**

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -885,16 +885,16 @@ EOF;
 
     /**
      * Checks whether last response matches the supplied json schema (https://json-schema.org/)
-     * Supply schema as filepath in your codeception data directory.
+     * Supply schema as relative file path in your project directory or an absolute path
      *
-     * @see codecept_data_dir()
+     * @see codecept_absolute_path()
      *
      * @param string $schemaFilename
      * @part json
      */
     public function seeResponseIsValidOnJsonSchema($schemaFilename)
     {
-        $file = codecept_data_dir() . $schemaFilename;
+        $file = codecept_absolute_path($schemaFilename);
         if (!file_exists($file)) {
             throw new ModuleException(__CLASS__, "File $file does not exist");
         }

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -833,9 +833,31 @@ EOF;
     }
 
     /**
-     * Checks whether last response matches the supplied json schema
-     * Supply schema as json string
+     * Checks whether last response matches the supplied json schema (https://json-schema.org/)
+     * Supply schema as json string.
      *
+     * Examples:
+     *
+     * ``` php
+     * <?php
+     * // response: {"name": "john", "age": 20}
+     * $I->seeResponseIsValidOnJsonSchema('{"type": "object"}');
+     *
+     * // response {"name": "john", "age": 20}
+     * $schema = [
+     *  "properties" => [
+     *      "age" => [
+     *          "type" => "integer",
+     *          "minimum" => 18
+     *      ]
+     *  ]
+     * ];
+     * $I->seeResponseIsValidOnJsonSchema(json_encode($schema));
+     *
+     * ?>
+     * ```
+     *
+     * @param string $schema
      * @part json
      */
     public function seeResponseIsValidOnJsonSchema($schema)

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -465,6 +465,21 @@ class RestTest extends Unit
         $this->module->seeResponseIsValidOnJsonSchema($validSchema);
     }
 
+    public function testSeeResponseIsValidOnJsonSchemachesJsonSchemaUsingExample() {
+        $this->setStubResponse('{"name": "john", "age": 20}');
+        $this->module->seeResponseIsValidOnJsonSchema('{"type": "object"}');
+
+        $schema = [
+            "properties" => [
+                "age" => [
+                    "type" => "integer",
+                    "minimum" => 18
+                ]
+            ]
+        ];
+        $this->module->seeResponseIsValidOnJsonSchema(json_encode($schema));
+    }
+
     /**
      * @param $configUrl
      * @param $requestUrl

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -456,18 +456,16 @@ class RestTest extends Unit
         $response = file_get_contents(codecept_data_dir($response));
         $this->setStubResponse($response);
 
-        $validSchema = file_get_contents(codecept_data_dir($schema));
-
         if (!$outcome) {
             $this->expectExceptionMessage($error);
             $this->shouldFail();
         }
-        $this->module->seeResponseIsValidOnJsonSchema($validSchema);
+        $this->module->seeResponseIsValidOnJsonSchema($schema);
     }
 
-    public function testSeeResponseIsValidOnJsonSchemachesJsonSchemaUsingExample() {
+    public function testSeeResponseIsValidOnJsonSchemachesJsonSchemaString() {
         $this->setStubResponse('{"name": "john", "age": 20}');
-        $this->module->seeResponseIsValidOnJsonSchema('{"type": "object"}');
+        $this->module->seeResponseIsValidOnJsonSchemaString('{"type": "object"}');
 
         $schema = [
             "properties" => [
@@ -477,7 +475,7 @@ class RestTest extends Unit
                 ]
             ]
         ];
-        $this->module->seeResponseIsValidOnJsonSchema(json_encode($schema));
+        $this->module->seeResponseIsValidOnJsonSchemaString(json_encode($schema));
     }
 
     /**

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -460,7 +460,7 @@ class RestTest extends Unit
             $this->expectExceptionMessage($error);
             $this->shouldFail();
         }
-        $this->module->seeResponseIsValidOnJsonSchema($schema);
+        $this->module->seeResponseIsValidOnJsonSchema(codecept_data_dir($schema));
     }
 
     public function testSeeResponseIsValidOnJsonSchemachesJsonSchemaString() {


### PR DESCRIPTION
Added some examples and link to https://json-schema.org/
Didn't implement passing a file reference.
I think supplying a string could be really helpful so you can create simple check's inline like I showed in the examples.
If supplying is required I would like to suggest a wrapper that allows a filename as parameter, will convert it and call this method.
