### PR TITLE
Negative values, >= and <= matchers and improved docs for Json Matchers

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -668,20 +668,25 @@ You can also apply filters to check values. Filter can be applied with `:` char 
 Here is the list of possible filters:
 
 * `integer:>{val}` - checks that integer is greater than {val} (works with float and string types too).
+* `integer:>={val}` - checks that integer is greater or equal than {val} (works with float and string types too).
 * `integer:<{val}` - checks that integer is lower than {val} (works with float and string types too).
+* `integer:<={val}` - checks that integer is lower or equal than {val} (works with float and string types too).
 * `string:url` - checks that value is valid url.
 * `string:date` - checks that value is date in JavaScript format: https://weblog.west-wind.com/posts/2014/Jan/06/JavaScript-JSON-Date-Parsing-and-real-Dates
 * `string:email` - checks that value is a valid email according to http://emailregex.com/
 * `string:regex({val})` - checks that string matches a regex provided with {val}
+* `string:empty` - checks that string is empty
 
 This is how filters can be used:
 
 ```php
 <?php
-// {'user_id': 1, 'email' => 'davert@codeception.com'}
+// {'user_id': 1, 'email' => 'davert@codeception.com', 'name': 'Michael Bodnarchuk', 'karma': -15}
 $I->seeResponseMatchesJsonType([
      'user_id' => 'string:>0:<1000', // multiple filters can be used
-     'email' => 'string:regex(~\@~)' // we just check that @ char is included
+     'email' => 'string:regex(~\@~)', // we just check that @ char is included
+     'name' => 'string:!empty', // we can check the opposite condition prepending the ! char
+     'karma' => 'integer:>-1000:<1000' // negative values can also be used                
 ]);
 
 // {'user_id': '1'}

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -228,10 +228,16 @@ class JsonType
         if (preg_match('~^regex\((.*?)\)$~', $filter, $matches)) {
             return preg_match($matches[1], $value);
         }
-        if (preg_match('~^>([\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('~^>=(-?[\d\.]+)$~', $filter, $matches)) {
+            return (float)$value >= (float)$matches[1];
+        }
+        if (preg_match('~^<=(-?[\d\.]+)$~', $filter, $matches)) {
+            return (float)$value <= (float)$matches[1];
+        }
+        if (preg_match('~^>(-?[\d\.]+)$~', $filter, $matches)) {
             return (float)$value > (float)$matches[1];
         }
-        if (preg_match('~^<([\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('~^<(-?[\d\.]+)$~', $filter, $matches)) {
             return (float)$value < (float)$matches[1];
         }
     }

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -40,6 +40,7 @@ class JsonTypeTest extends \Codeception\Test\Unit
 
     public function testIntegerFilter()
     {
+        $this->data['karma'] = -15;
         $jsonType = new JsonType($this->data);
         $this->assertStringContainsString('`id: 11` is of type', $jsonType->matches(['id' => 'integer:<5']));
         $this->assertStringContainsString('`id: 11` is of type', $jsonType->matches(['id' => 'integer:>15']));
@@ -47,6 +48,24 @@ class JsonTypeTest extends \Codeception\Test\Unit
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5']));
         $this->assertTrue($jsonType->matches(['id' => 'integer:>5:<12']));
         $this->assertNotTrue($jsonType->matches(['id' => 'integer:>5:<10']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:>=10']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:>=11']));
+        $this->assertNotTrue($jsonType->matches(['id' => 'integer:>=12']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:<=11']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:<=12']));
+        $this->assertNotTrue($jsonType->matches(['id' => 'integer:<=10']));
+        $this->assertTrue($jsonType->matches(['id' => 'integer:<=11:>=11:<=12:>=10']));
+        $this->assertNotTrue($jsonType->matches(['id' => 'integer:<=11:>=11:<=12:<=10']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:<-14']));
+        $this->assertNotTrue($jsonType->matches(['karma' => 'integer:<-15']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:>-16']));
+        $this->assertNotTrue($jsonType->matches(['karma' => 'integer:>-15']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:<=-14']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:<=-15']));
+        $this->assertNotTrue($jsonType->matches(['karma' => 'integer:<=-16']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:>=-16']));
+        $this->assertTrue($jsonType->matches(['karma' => 'integer:>=-15']));
+        $this->assertNotTrue($jsonType->matches(['karma' => 'integer:>=-14']));
     }
 
     public function testUrlFilter()


### PR DESCRIPTION
Hi,

I was testing an API that included numbers, discounts and negative values, and I thought that would come handy having "greater or equal than" and "lower or equal than" matchers and support for negative numbers built-in. 

Besides, I took some time to improve the documentation for the `seeResponseMatchesJsonType`, as IMHO is one of the most powerful methods for testing API responses and it offers more than the documentation implied, which always led me to analyse the implementation to obtain some of its hidden (but nice) features.

I also modified the unit tests to support the new matchers and negative numbers.

Please, let me know of any comment you might have.