### PR TITLE
Add a generic send action

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -538,6 +538,21 @@ EOF;
     }
 
     /**
+     * Sends a HTTP request.
+     *
+     * @param $method
+     * @param $url
+     * @param array|\JsonSerializable $params
+     * @param array $files
+     * @part json
+     * @part xml
+     */
+    public function send($method, $url, $params = [], $files = [])
+    {
+        $this->execute($method, $url, $params, $files);
+    }
+
+    /**
      * Sets Headers "Link" as one header "Link" based on linkEntries
      *
      * @param array $linkEntries (entry is array with keys "uri" and "link-param")


### PR DESCRIPTION
Added a `send()` method which accepts a `$method` argument as a sting.

I didn't make the `execute()` method public in order to keep the naming consistent with the rest of the `send...()` methods.
A also didn't rename `execute()` to preserve backward compatibility which will be lost otherwise.

A use-case would be to pass a request method in a data provider:

```php
/**
 * @dataProvider provider
 */
public function test(ApiTester $I, Example $example): void
{
    $uri = 'https://example.tld/endpoint';
    $method = $example['method'];
    $data = $example['data'];

    $I->send($method, $uri, $data);
    $I->seeResponseCodeIs($example['status-code']);
}

private function provider(): array
{
    return [
        [
            'method' => 'PUT',
            'data' => [
                'foo' => 'bar',
            ],
            'status-code' => HttpCode::OK,
        ],
        [
            'method' => 'PATCH',
            'data' => [
                'foo' => 'bar',
            ],
            'status-code' => HttpCode::OK,
        ],
    ];    
}
```