### PR TITLE
Url and Params validation, OPTIONS doesn't send body

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -400,7 +400,7 @@ EOF;
      * ?>
      * ```
      * @param array $additionalAWSConfig
-     * @throws ModuleException
+     * @throws ConfigurationException
      */
     public function amAWSAuthenticated($additionalAWSConfig = [])
     {

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1581,8 +1581,8 @@ EOF;
      * ?>
      * ```
      *
-     * @param $hash the hashed data response expected
-     * @param $algo the hash algorithm to use. Default md5.
+     * @param string $hash the hashed data response expected
+     * @param string $algo the hash algorithm to use. Default md5.
      * @part json
      * @part xml
      */
@@ -1602,8 +1602,8 @@ EOF;
      * ```
      * Opposite to `seeBinaryResponseEquals`
      *
-     * @param $hash the hashed data response expected
-     * @param $algo the hash algorithm to use. Default md5.
+     * @param string $hash the hashed data response expected
+     * @param string $algo the hash algorithm to use. Default md5.
      * @part json
      * @part xml
      */

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -561,7 +561,7 @@ EOF;
      */
     public function send($method, $url, $params = [], $files = [])
     {
-        $this->execute($method, $url, $params, $files);
+        $this->execute(strtoupper($method), $url, $params, $files);
     }
 
     /**

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -648,13 +648,6 @@ EOF;
             }
         } else {
             $parameters = $this->encodeApplicationJson($method, $parameters);
-
-            if (!is_string($parameters) && !is_array($parameters)) {
-                if ($parameters instanceof \JsonSerializable) {
-                    throw new ModuleException(__CLASS__, $method . ' parameters is JsonSerializable object, but Content-Type header is not set to application/json');
-                }
-                throw new ModuleException(__CLASS__, $method . ' parameters must be array, string or object implementing JsonSerializable interface');
-            }
         }
 
         if (is_array($parameters) || $isQueryParamsAwareMethod) {
@@ -735,6 +728,15 @@ EOF;
                 return json_encode($parameters);
             }
         }
+
+        if ($parameters instanceof \JsonSerializable) {
+            throw new ModuleException(__CLASS__, $method . ' parameters is JsonSerializable object, but Content-Type header is not set to application/json');
+        }
+
+        if (!is_string($parameters) && !is_array($parameters)) {
+            throw new ModuleException(__CLASS__, $method . ' parameters must be array, string or object implementing JsonSerializable interface');
+        }
+
         return $parameters;
     }
 

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -453,7 +453,7 @@ EOF;
      * ```
      *
      * @param $url
-     * @param array|\JsonSerializable $params
+     * @param array|string|\JsonSerializable $params
      * @param array $files A list of filenames or "mocks" of $_FILES (each entry being an array with the following
      *                     keys: name, type, error, size, tmp_name (pointing to the real file path). Each key works
      *                     as the "name" attribute of a file input field.
@@ -511,7 +511,7 @@ EOF;
      * Sends PUT request to given uri.
      *
      * @param $url
-     * @param array $params
+     * @param array|string|\JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml
@@ -525,7 +525,7 @@ EOF;
      * Sends PATCH request to given uri.
      *
      * @param       $url
-     * @param array $params
+     * @param array|string|\JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml
@@ -554,7 +554,7 @@ EOF;
      *
      * @param $method
      * @param $url
-     * @param array|\JsonSerializable $params
+     * @param array|string|\JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -638,19 +638,26 @@ EOF;
 
         $this->params = $parameters;
 
-        $parameters = $this->encodeApplicationJson($method, $parameters);
         $isQueryParamsAwareMethod = in_array($method, self::QUERY_PARAMS_AWARE_METHODS, true);
 
-        if (is_array($parameters) || $isQueryParamsAwareMethod) {
-            if (!empty($parameters) && $isQueryParamsAwareMethod) {
-                if (strpos($url, '?') !== false) {
-                    $url .= '&';
-                } else {
-                    $url .= '?';
-                }
-                $url .= http_build_query($parameters);
+        if ($isQueryParamsAwareMethod) {
+            if (!is_array($parameters)) {
+                throw new ModuleException(__CLASS__, $method . ' parameters must be passed in array format');
             }
+        } else {
+            $parameters = $this->encodeApplicationJson($method, $parameters);
+        }
+
+        if (is_array($parameters) || $isQueryParamsAwareMethod) {
             if ($isQueryParamsAwareMethod) {
+                if (!empty($parameters)) {
+                    if (strpos($url, '?') !== false) {
+                        $url .= '&';
+                    } else {
+                        $url .= '?';
+                    }
+                    $url .= http_build_query($parameters);
+                }
                 $this->debugSection("Request", "$method $url");
                 $files = [];
             } else {
@@ -707,7 +714,6 @@ EOF;
     {
         if (
             array_key_exists('Content-Type', $this->connectionModule->headers)
-            && !in_array($method, self::QUERY_PARAMS_AWARE_METHODS, true)
             && ($this->connectionModule->headers['Content-Type'] === 'application/json'
                 || preg_match('!^application/.+\+json$!', $this->connectionModule->headers['Content-Type'])
             )

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -83,7 +83,7 @@ use JsonSchema\Constraints\Constraint as JsonContraint;
  */
 class REST extends CodeceptionModule implements DependsOnModule, PartedModule, API, ConflictsWithModule
 {
-    const QUERY_PARAMS_AWARE_METHODS = ['GET', 'HEAD', 'DELETE'];
+    const QUERY_PARAMS_AWARE_METHODS = ['GET', 'HEAD', 'DELETE', 'OPTIONS'];
 
     protected $config = [
         'url' => '',

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -997,7 +997,6 @@ EOF;
      * @return string
      * @part json
      * @part xml
-     * @version 1.1
      */
     public function grabResponse()
     {
@@ -1021,7 +1020,6 @@ EOF;
      * @return array Array of matching items
      * @throws \Exception
      * @part json
-     * @version 2.0.9
      */
     public function grabDataFromResponseByJsonPath($jsonPath)
     {
@@ -1067,7 +1065,6 @@ EOF;
      * ```
      * @param string $xpath
      * @part json
-     * @version 2.0.9
      */
     public function seeResponseJsonMatchesXpath($xpath)
     {
@@ -1134,7 +1131,6 @@ EOF;
      *
      * @param string $jsonPath
      * @part json
-     * @version 2.0.9
      */
     public function seeResponseJsonMatchesJsonPath($jsonPath)
     {
@@ -1259,7 +1255,6 @@ EOF;
      * @param array $jsonType
      * @param string $jsonPath
      * @see JsonType
-     * @version 2.1.3
      */
     public function seeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
     {

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1275,12 +1275,11 @@ EOF;
      * Opposite to `seeResponseMatchesJsonType`.
      *
      * @part json
-     * @param $jsonType jsonType structure
-     * @param null $jsonPath optionally set specific path to structure with JsonPath
+     * @param array $jsonType JsonType structure
+     * @param string $jsonPath
      * @see seeResponseMatchesJsonType
-     * @version 2.1.3
      */
-    public function dontSeeResponseMatchesJsonType($jsonType, $jsonPath = null)
+    public function dontSeeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
     {
         $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -632,6 +632,8 @@ EOF;
         // allow full url to be requested
         if (!$url) {
             $url = $this->config['url'];
+        } elseif (!is_string($url)) {
+            throw new ModuleException(__CLASS__, 'URL must be string');
         } elseif (strpos($url, '://') === false && $this->config['url']) {
             $url = rtrim($this->config['url'], '/') . '/' . ltrim($url, '/');
         }
@@ -646,6 +648,13 @@ EOF;
             }
         } else {
             $parameters = $this->encodeApplicationJson($method, $parameters);
+
+            if (!is_string($parameters) && !is_array($parameters)) {
+                if ($parameters instanceof \JsonSerializable) {
+                    throw new ModuleException(__CLASS__, $method . ' parameters is JsonSerializable object, but Content-Type header is not set to application/json');
+                }
+                throw new ModuleException(__CLASS__, $method . ' parameters must be array, string or object implementing JsonSerializable interface');
+            }
         }
 
         if (is_array($parameters) || $isQueryParamsAwareMethod) {

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -240,5 +240,7 @@ class JsonType
         if (preg_match('~^<(-?[\d\.]+)$~', $filter, $matches)) {
             return (float)$value < (float)$matches[1];
         }
+
+        return false;
     }
 }

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -243,7 +243,7 @@ class RestTest extends Unit
      */
     public function testThrowsExceptionIfParametersIsString($method)
     {
-        $this->expectExceptionMessage($method, ' parameters must be passed in array format');
+        $this->expectExceptionMessage($method . ' parameters must be passed in array format');
         $this->module->send($method, '/', 'string');
     }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -87,6 +87,13 @@ class RestTest extends Unit
         $this->module->dontSeeResponseContainsJson(['name' => 'john']);
     }
 
+    public function testSend()
+    {
+        $this->module->send('POST','/rest/user/', ['name' => 'john']);
+        $this->module->seeResponseContains('john');
+        $this->module->seeResponseContainsJson(['name' => 'john']);
+    }
+
     public function testGrabDataFromResponseByJsonPath()
     {
         $this->module->sendGET('/rest/user/');

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -220,9 +220,8 @@ class RestTest extends Unit
      */
     public function testGetApplicationJsonNotIncludesJsonAsContent($method)
     {
-        $method = 'send' . $method;
         $this->module->haveHttpHeader('Content-Type', 'application/json');
-        $this->module->$method('/', ['name' => 'john']);
+        $this->module->send($method, '/', ['name' => 'john']);
         /** @var $request \Symfony\Component\BrowserKit\Request  **/
         $request = $this->module->client->getRequest();
         $this->assertNull($request->getContent());
@@ -232,9 +231,20 @@ class RestTest extends Unit
     public function queryParamsAwareMethods()
     {
         return [
-            ['Get'],
-            ['Head'],
+            'GET'     => ['GET'],
+            'HEAD'    => ['HEAD'],
+            'DELETE'  => ['DELETE'],
+            'OPTIONS' => ['OPTIONS'],
         ];
+    }
+
+    /**
+     * @dataProvider queryParamsAwareMethods
+     */
+    public function testRequestThrowsExceptionIfParametersIsString($method)
+    {
+        $this->expectExceptionMessage($method, ' parameters must be passed in array format');
+        $this->module->send($method, '/', 'string');
     }
 
     public function testUrlIsFull()


### PR DESCRIPTION
* Don't send request body with OPTIONS request
* Send method: convert method name to uppercase
* Validate url and params parameters
* Document that sendPost, sendPut, sendPatch accept string and JsonSerializable as params

Depends on https://github.com/Codeception/lib-innerbrowser/pull/34