### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
     
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -1,33 +1,37 @@
 {
-    "name":"codeception/module-rest",
-    "description":"REST module for Codeception",
-    "keywords":["codeception", "rest"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "softcreatr/jsonpath": "^0.5 || ^0.7",
-        "codeception/codeception": "^4.0",
-        "justinrainbow/json-schema": "~5.2.9"
-    },
-    "require-dev": {
-        "codeception/util-universalframework": "^1.0",
-        "codeception/lib-innerbrowser": "^1.0"
-    },
-    "suggest": {
-        "aws/aws-sdk-php": "For using AWS Auth"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-rest",
+	"description": "REST module for Codeception",
+	"keywords": [ "codeception", "rest" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"ext-dom": "*",
+		"ext-json": "*",
+		"codeception/codeception": "^4.0",
+		"justinrainbow/json-schema": "~5.2.9",
+		"softcreatr/jsonpath": "^0.5 || ^0.7"
+	},
+	"require-dev": {
+		"codeception/util-universalframework": "^1.0",
+		"codeception/lib-innerbrowser": "^1.0"
+	},
+	"suggest": {
+		"aws/aws-sdk-php": "For using AWS Auth"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A REST module for Codeception
 [![Total Downloads](https://poser.pugx.org/codeception/module-rest/downloads)](https://packagist.org/packages/codeception/module-rest)
 [![License](https://poser.pugx.org/codeception/module-rest/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -218,14 +218,12 @@ EOF;
      * <?php
      * $I->haveHttpHeader('Content-Type', 'application/json');
      * // all next requests will contain this header
-    * ```
+     * ```
      *
-     * @param $name
-     * @param $value
      * @part json
      * @part xml
      */
-    public function haveHttpHeader($name, $value): void
+    public function haveHttpHeader(string $name, string $value): void
     {
         $this->connectionModule->haveHttpHeader($name, $value);
     }
@@ -242,7 +240,7 @@ EOF;
      * // ...
      * $I->deleteHeader('X-Requested-With');
      * $I->sendPost('some-other-page.php');
-    * ```
+     * ```
      *
      * @param string $name the name of the header to delete.
      * @part json
@@ -351,12 +349,10 @@ EOF;
     /**
      * Adds Digest authentication via username/password.
      *
-     * @param $username
-     * @param $password
      * @part json
      * @part xml
      */
-    public function amDigestAuthenticated($username, $password): void
+    public function amDigestAuthenticated(string $username, string $password): void
     {
         if ($this->isFunctional) {
             throw new ModuleException(__METHOD__, 'Not supported by functional modules');
@@ -387,13 +383,11 @@ EOF;
      * $I->amNTLMAuthenticated('jon_snow', 'targaryen');
      * ```
      *
-     * @param $username
-     * @param $password
      * @throws ModuleException
      * @part json
      * @part xml
      */
-    public function amNTLMAuthenticated($username, $password): void
+    public function amNTLMAuthenticated(string $username, string $password): void
     {
         if ($this->isFunctional) {
             throw new ModuleException(__METHOD__, 'Not supported by functional modules');
@@ -477,7 +471,6 @@ EOF;
      * ]]);
      * ```
      *
-     * @param $url
      * @param array|string|JsonSerializable $params
      * @param array $files A list of filenames or "mocks" of $_FILES (each entry being an array with the following
      *                     keys: name, type, error, size, tmp_name (pointing to the real file path). Each key works
@@ -488,7 +481,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendPost($url, $params = [], array $files = []): void
+    public function sendPost(string $url, $params = [], array $files = []): void
     {
         $this->execute('POST', $url, $params, $files);
     }
@@ -496,12 +489,10 @@ EOF;
     /**
      * Sends a HEAD request to given uri.
      *
-     * @param $url
-     * @param array $params
      * @part json
      * @part xml
      */
-    public function sendHead($url, array $params = []): void
+    public function sendHead(string $url, array $params = []): void
     {
         $this->execute('HEAD', $url, $params);
     }
@@ -509,12 +500,10 @@ EOF;
     /**
      * Sends an OPTIONS request to given uri.
      *
-     * @param $url
-     * @param array $params
      * @part json
      * @part xml
      */
-    public function sendOptions($url, array $params = []): void
+    public function sendOptions(string $url, array $params = []): void
     {
         $this->execute('OPTIONS', $url, $params);
     }
@@ -522,12 +511,10 @@ EOF;
     /**
      * Sends a GET request to given uri.
      *
-     * @param $url
-     * @param array $params
      * @part json
      * @part xml
      */
-    public function sendGet($url, array $params = []): void
+    public function sendGet(string $url, array $params = []): void
     {
         $this->execute('GET', $url, $params);
     }
@@ -535,13 +522,11 @@ EOF;
     /**
      * Sends PUT request to given uri.
      *
-     * @param $url
      * @param array|string|JsonSerializable $params
-     * @param array $files
      * @part json
      * @part xml
      */
-    public function sendPut($url, $params = [], array $files = []): void
+    public function sendPut(string $url, $params = [], array $files = []): void
     {
         $this->execute('PUT', $url, $params, $files);
     }
@@ -549,13 +534,11 @@ EOF;
     /**
      * Sends PATCH request to given uri.
      *
-     * @param       $url
      * @param array|string|JsonSerializable $params
-     * @param array $files
      * @part json
      * @part xml
      */
-    public function sendPatch($url, $params = [], array $files = []): void
+    public function sendPatch(string $url, $params = [], array $files = []): void
     {
         $this->execute('PATCH', $url, $params, $files);
     }
@@ -563,13 +546,10 @@ EOF;
     /**
      * Sends DELETE request to given uri.
      *
-     * @param $url
-     * @param array $params
-     * @param array $files
      * @part json
      * @part xml
      */
-    public function sendDelete($url, array $params = [], array $files = []): void
+    public function sendDelete(string $url, array $params = [], array $files = []): void
     {
         $this->execute('DELETE', $url, $params, $files);
     }
@@ -577,14 +557,11 @@ EOF;
     /**
      * Sends a HTTP request.
      *
-     * @param $method
-     * @param $url
      * @param array|string|JsonSerializable $params
-     * @param array $files
      * @part json
      * @part xml
      */
-    public function send($method, $url, $params = [], array $files = []): void
+    public function send(string $method, string $url, $params = [], array $files = []): void
     {
         $this->execute(strtoupper($method), $url, $params, $files);
     }
@@ -621,7 +598,6 @@ EOF;
     /**
      * Sends LINK request to given uri.
      *
-     * @param       $url
      * @param array $linkEntries (entry is array with keys "uri" and "link-param")
      *
      * @link http://tools.ietf.org/html/rfc2068#section-19.6.2.4
@@ -630,7 +606,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendLink($url, array $linkEntries): void
+    public function sendLink(string $url, array $linkEntries): void
     {
         $this->setHeaderLink($linkEntries);
         $this->execute('LINK', $url);
@@ -639,14 +615,13 @@ EOF;
     /**
      * Sends UNLINK request to given uri.
      *
-     * @param       $url
      * @param array $linkEntries (entry is array with keys "uri" and "link-param")
      * @link http://tools.ietf.org/html/rfc2068#section-19.6.2.4
      * @author samva.ua@gmail.com
      * @part json
      * @part xml
      */
-    public function sendUnlink($url, array $linkEntries): void
+    public function sendUnlink(string $url, array $linkEntries): void
     {
         $this->setHeaderLink($linkEntries);
         $this->execute('UNLINK', $url);
@@ -737,7 +712,7 @@ EOF;
         return '[binary-data length:' . strlen($data) . ' md5:' . md5($data) . ']';
     }
 
-    protected function encodeApplicationJson($method, $parameters)
+    protected function encodeApplicationJson(string $method, $parameters)
     {
         if (
             array_key_exists('Content-Type', $this->connectionModule->headers)
@@ -810,10 +785,7 @@ EOF;
         return $files;
     }
 
-    /**
-     * @return string|bool
-     */
-    private function getFileType($file)
+    private function getFileType($file): string
     {
         if (function_exists('mime_content_type') && mime_content_type($file)) {
             return mime_content_type($file);
@@ -821,7 +793,7 @@ EOF;
         return 'application/octet-stream';
     }
 
-    private function checkFileBeforeUpload($file): void
+    private function checkFileBeforeUpload(string $file): void
     {
         if (!file_exists($file)) {
             throw new ModuleException(__CLASS__, sprintf('File %s does not exist', $file));
@@ -1087,7 +1059,6 @@ EOF;
      * // at least one item in store has price
      * $I->seeResponseJsonMatchesXpath('/store//price');
      * ```
-     * @param string $xPath
      * @part json
      */
     public function seeResponseJsonMatchesXpath(string $xPath): void
@@ -1103,7 +1074,6 @@ EOF;
     /**
      * Opposite to seeResponseJsonMatchesXpath
      *
-     * @param string $xPath
      * @part json
      */
     public function dontSeeResponseJsonMatchesXpath(string $xPath): void
@@ -1328,9 +1298,8 @@ EOF;
      *
      * @part json
      * @part xml
-     * @param $code
      */
-    public function seeResponseCodeIs($code): void
+    public function seeResponseCodeIs(int $code): void
     {
         $this->connectionModule->seeResponseCodeIs($code);
     }
@@ -1348,9 +1317,8 @@ EOF;
      *
      * @part json
      * @part xml
-     * @param $code
      */
-    public function dontSeeResponseCodeIs($code): void
+    public function dontSeeResponseCodeIs(int $code): void
     {
         $this->connectionModule->dontSeeResponseCodeIs($code);
     }
@@ -1434,9 +1402,8 @@ EOF;
      * $I->seeXmlResponseMatchesXpath('//root/user[@id=1]');
      * ```
      * @part xml
-     * @param $xPath
      */
-    public function seeXmlResponseMatchesXpath($xPath): void
+    public function seeXmlResponseMatchesXpath(string $xPath): void
     {
         $xmlStructure = new XmlStructure($this->connectionModule->_getResponseContent());
         $this->assertTrue($xmlStructure->matchesXpath($xPath), 'xpath not matched');
@@ -1450,9 +1417,8 @@ EOF;
      * $I->dontSeeXmlResponseMatchesXpath('//root/user[@id=1]');
      * ```
      * @part xml
-     * @param $xPath
      */
-    public function dontSeeXmlResponseMatchesXpath($xPath): void
+    public function dontSeeXmlResponseMatchesXpath(string $xPath): void
     {
         $structure = new XmlStructure($this->connectionModule->_getResponseContent());
         $this->assertFalse($structure->matchesXpath($xPath), 'accidentally matched xpath');
@@ -1476,12 +1442,9 @@ EOF;
      * Finds and returns attribute of element.
      * Element is matched by either CSS or XPath
      *
-     * @param $cssOrXPath
-     * @param $attribute
-     * @return string
      * @part xml
      */
-    public function grabAttributeFromXmlElement(string $cssOrXPath, $attribute): string
+    public function grabAttributeFromXmlElement(string $cssOrXPath, string $attribute): string
     {
         $el = (new XmlStructure($this->connectionModule->_getResponseContent()))->matchElement($cssOrXPath);
         if (!$el->hasAttribute($attribute)) {

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
+use ArrayAccess;
 use Codeception\Exception\ConfigurationException;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Interfaces\ConflictsWithModule;
-use Codeception\Module as CodeceptionModule;
+use Codeception\Module;
 use Codeception\PHPUnit\Constraint\JsonContains;
 use Codeception\PHPUnit\Constraint\JsonType as JsonTypeConstraint;
 use Codeception\TestInterface;
@@ -19,8 +22,13 @@ use Codeception\Util\JsonArray;
 use Codeception\Util\JsonType;
 use Codeception\Util\XmlStructure;
 use Codeception\Util\Soap as XmlUtils;
+use Exception;
 use JsonSchema\Validator as JsonSchemaValidator;
-use JsonSchema\Constraints\Constraint as JsonContraint;
+use JsonSchema\Constraints\Constraint as JsonConstraint;
+use JsonSerializable;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * Module for testing REST WebService.
@@ -81,15 +89,24 @@ use JsonSchema\Constraints\Constraint as JsonContraint;
  * Conflicts with SOAP module
  *
  */
-class REST extends CodeceptionModule implements DependsOnModule, PartedModule, API, ConflictsWithModule
+class REST extends Module implements DependsOnModule, PartedModule, API, ConflictsWithModule
 {
+    /**
+     * @var string[]
+     */
     const QUERY_PARAMS_AWARE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
 
+    /**
+     * @var array<string, string>
+     */
     protected $config = [
         'url' => '',
         'aws' => ''
     ];
 
+    /**
+     * @var string
+     */
     protected $dependencyMessage = <<<EOF
 Example configuring PhpBrowser as backend for REST module.
 --
@@ -103,12 +120,19 @@ modules:
 Framework modules can be used for testing of API as well.
 EOF;
 
+    /**
+     * @var int
+     */
     protected $DEFAULT_SHORTEN_VALUE = 150;
 
     /**
-     * @var \Symfony\Component\HttpKernel\HttpKernelBrowser|\Symfony\Component\BrowserKit\AbstractBrowser
+     * @var HttpKernelBrowser|AbstractBrowser
      */
-    public $client = null;
+    public $client;
+
+    /**
+     * @var bool
+     */
     public $isFunctional = false;
 
     /**
@@ -116,8 +140,15 @@ EOF;
      */
     protected $connectionModule;
 
+    /**
+     * @var array
+     */
     public $params = [];
-    public $response = "";
+
+    /**
+     * @var string
+     */
+    public $response = '';
 
     public function _before(TestInterface $test)
     {
@@ -125,21 +156,21 @@ EOF;
         $this->resetVariables();
     }
 
-    protected function resetVariables()
+    protected function resetVariables(): void
     {
         $this->params = [];
-        $this->response = "";
+        $this->response = '';
         $this->connectionModule->headers = [];
     }
 
     public function _conflicts()
     {
-        return 'Codeception\Lib\Interfaces\API';
+        return \Codeception\Lib\Interfaces\API::class;
     }
 
     public function _depends()
     {
-        return ['Codeception\Lib\InnerBrowser' => $this->dependencyMessage];
+        return [\Codeception\Lib\InnerBrowser::class => $this->dependencyMessage];
     }
 
     public function _parts()
@@ -172,8 +203,7 @@ EOF;
         $test->getMetadata()->addReport('body', $printedResponse);
     }
 
-
-    protected function getRunningClient()
+    protected function getRunningClient(): AbstractBrowser
     {
         if ($this->client->getInternalRequest() === null) {
             throw new ModuleException($this, "Response is empty. Use `\$I->sendXXX()` methods to send HTTP request");
@@ -188,15 +218,14 @@ EOF;
      * <?php
      * $I->haveHttpHeader('Content-Type', 'application/json');
      * // all next requests will contain this header
-     * ?>
-     * ```
+    * ```
      *
      * @param $name
      * @param $value
      * @part json
      * @part xml
      */
-    public function haveHttpHeader($name, $value)
+    public function haveHttpHeader($name, $value): void
     {
         $this->connectionModule->haveHttpHeader($name, $value);
     }
@@ -213,14 +242,13 @@ EOF;
      * // ...
      * $I->deleteHeader('X-Requested-With');
      * $I->sendPost('some-other-page.php');
-     * ?>
-     * ```
+    * ```
      *
      * @param string $name the name of the header to delete.
      * @part json
      * @part xml
      */
-    public function deleteHeader($name)
+    public function deleteHeader(string $name): void
     {
         $this->connectionModule->deleteHeader($name);
     }
@@ -229,12 +257,12 @@ EOF;
      * Checks over the given HTTP header and (optionally)
      * its value, asserting that are there
      *
-     * @param $name
+     * @param string $name
      * @param $value
      * @part json
      * @part xml
      */
-    public function seeHttpHeader($name, $value = null)
+    public function seeHttpHeader(string $name, $value = null): void
     {
         if ($value !== null) {
             $this->assertEquals(
@@ -250,12 +278,12 @@ EOF;
      * Checks over the given HTTP header and (optionally)
      * its value, asserting that are not there
      *
-     * @param $name
+     * @param string $name
      * @param $value
      * @part json
      * @part xml
      */
-    public function dontSeeHttpHeader($name, $value = null)
+    public function dontSeeHttpHeader(string $name, $value = null): void
     {
         if ($value !== null) {
             $this->assertNotEquals(
@@ -275,14 +303,13 @@ EOF;
      * ``` php
      * <?php
      * $I->seeHttpHeaderOnce('Cache-Control');
-     * ?>>
      * ```
      *
-     * @param $name
+     * @param string $name
      * @part json
      * @part xml
      */
-    public function seeHttpHeaderOnce($name)
+    public function seeHttpHeaderOnce(string $name): void
     {
         $headers = $this->getRunningClient()->getInternalResponse()->getHeader($name, false);
         $this->assertCount(1, $headers);
@@ -291,14 +318,14 @@ EOF;
     /**
      * Returns the value of the specified header name
      *
-     * @param $name
-     * @param Boolean $first Whether to return the first value or all header values
+     * @param string $name
+     * @param bool $first Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      * @part json
      * @part xml
      */
-    public function grabHttpHeader($name, $first = true)
+    public function grabHttpHeader(string $name, bool $first = true)
     {
         return $this->getRunningClient()->getInternalResponse()->getHeader($name, $first);
     }
@@ -306,12 +333,12 @@ EOF;
     /**
      * Adds HTTP authentication via username/password.
      *
-     * @param $username
-     * @param $password
+     * @param string $username
+     * @param string $password
      * @part json
      * @part xml
      */
-    public function amHttpAuthenticated($username, $password)
+    public function amHttpAuthenticated(string $username, string $password): void
     {
         if ($this->isFunctional) {
             $this->client->setServerParameter('PHP_AUTH_USER', $username);
@@ -329,7 +356,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function amDigestAuthenticated($username, $password)
+    public function amDigestAuthenticated($username, $password): void
     {
         if ($this->isFunctional) {
             throw new ModuleException(__METHOD__, 'Not supported by functional modules');
@@ -340,11 +367,11 @@ EOF;
     /**
      * Adds Bearer authentication via access token.
      *
-     * @param $accessToken
+     * @param string $accessToken
      * @part json
      * @part xml
      */
-    public function amBearerAuthenticated($accessToken)
+    public function amBearerAuthenticated(string $accessToken): void
     {
         $this->haveHttpHeader('Authorization', 'Bearer ' . $accessToken);
     }
@@ -358,7 +385,6 @@ EOF;
      * ```php
      * <?php
      * $I->amNTLMAuthenticated('jon_snow', 'targaryen');
-     * ?>
      * ```
      *
      * @param $username
@@ -367,7 +393,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function amNTLMAuthenticated($username, $password)
+    public function amNTLMAuthenticated($username, $password): void
     {
         if ($this->isFunctional) {
             throw new ModuleException(__METHOD__, 'Not supported by functional modules');
@@ -397,12 +423,11 @@ EOF;
      * ```php
      * <?php
      * $I->amAWSAuthenticated();
-     * ?>
      * ```
      * @param array $additionalAWSConfig
      * @throws ConfigurationException
      */
-    public function amAWSAuthenticated($additionalAWSConfig = [])
+    public function amAWSAuthenticated(array $additionalAWSConfig = []): void
     {
         if (method_exists($this->client, 'setAwsAuth')) {
             $config = array_merge($this->config['aws'], $additionalAWSConfig);
@@ -453,7 +478,7 @@ EOF;
      * ```
      *
      * @param $url
-     * @param array|string|\JsonSerializable $params
+     * @param array|string|JsonSerializable $params
      * @param array $files A list of filenames or "mocks" of $_FILES (each entry being an array with the following
      *                     keys: name, type, error, size, tmp_name (pointing to the real file path). Each key works
      *                     as the "name" attribute of a file input field.
@@ -463,7 +488,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendPost($url, $params = [], $files = [])
+    public function sendPost($url, $params = [], array $files = []): void
     {
         $this->execute('POST', $url, $params, $files);
     }
@@ -476,7 +501,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendHead($url, $params = [])
+    public function sendHead($url, array $params = []): void
     {
         $this->execute('HEAD', $url, $params);
     }
@@ -489,7 +514,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendOptions($url, $params = [])
+    public function sendOptions($url, array $params = []): void
     {
         $this->execute('OPTIONS', $url, $params);
     }
@@ -502,7 +527,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendGet($url, $params = [])
+    public function sendGet($url, array $params = []): void
     {
         $this->execute('GET', $url, $params);
     }
@@ -511,12 +536,12 @@ EOF;
      * Sends PUT request to given uri.
      *
      * @param $url
-     * @param array|string|\JsonSerializable $params
+     * @param array|string|JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml
      */
-    public function sendPut($url, $params = [], $files = [])
+    public function sendPut($url, $params = [], array $files = []): void
     {
         $this->execute('PUT', $url, $params, $files);
     }
@@ -525,12 +550,12 @@ EOF;
      * Sends PATCH request to given uri.
      *
      * @param       $url
-     * @param array|string|\JsonSerializable $params
+     * @param array|string|JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml
      */
-    public function sendPatch($url, $params = [], $files = [])
+    public function sendPatch($url, $params = [], array $files = []): void
     {
         $this->execute('PATCH', $url, $params, $files);
     }
@@ -544,7 +569,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendDelete($url, $params = [], $files = [])
+    public function sendDelete($url, array $params = [], array $files = []): void
     {
         $this->execute('DELETE', $url, $params, $files);
     }
@@ -554,12 +579,12 @@ EOF;
      *
      * @param $method
      * @param $url
-     * @param array|string|\JsonSerializable $params
+     * @param array|string|JsonSerializable $params
      * @param array $files
      * @part json
      * @part xml
      */
-    public function send($method, $url, $params = [], $files = [])
+    public function send($method, $url, $params = [], array $files = []): void
     {
         $this->execute(strtoupper($method), $url, $params, $files);
     }
@@ -573,16 +598,16 @@ EOF;
      *
      * @author samva.ua@gmail.com
      */
-    private function setHeaderLink(array $linkEntries)
+    private function setHeaderLink(array $linkEntries): void
     {
         $values = [];
         foreach ($linkEntries as $linkEntry) {
-            \PHPUnit\Framework\Assert::assertArrayHasKey(
+            Assert::assertArrayHasKey(
                 'uri',
                 $linkEntry,
                 'linkEntry should contain property "uri"'
             );
-            \PHPUnit\Framework\Assert::assertArrayHasKey(
+            Assert::assertArrayHasKey(
                 'link-param',
                 $linkEntry,
                 'linkEntry should contain property "link-param"'
@@ -605,7 +630,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendLink($url, array $linkEntries)
+    public function sendLink($url, array $linkEntries): void
     {
         $this->setHeaderLink($linkEntries);
         $this->execute('LINK', $url);
@@ -621,13 +646,13 @@ EOF;
      * @part json
      * @part xml
      */
-    public function sendUnlink($url, array $linkEntries)
+    public function sendUnlink($url, array $linkEntries): void
     {
         $this->setHeaderLink($linkEntries);
         $this->execute('UNLINK', $url);
     }
 
-    protected function execute($method, $url, $parameters = [], $files = [])
+    protected function execute($method, $url, $parameters = [], $files = []): void
     {
         // allow full url to be requested
         if (!$url) {
@@ -660,23 +685,23 @@ EOF;
                     }
                     $url .= http_build_query($parameters);
                 }
-                $this->debugSection("Request", "$method $url");
+                $this->debugSection("Request", sprintf('%s %s', $method, $url));
                 $files = [];
             } else {
-                $this->debugSection("Request", "$method $url " . json_encode($parameters));
+                $this->debugSection("Request", sprintf('%s %s ', $method, $url) . json_encode($parameters));
                 $files = $this->formatFilesArray($files);
             }
-            $this->response = (string)$this->connectionModule->_request($method, $url, $parameters, $files);
+            $this->response = $this->connectionModule->_request($method, $url, $parameters, $files);
         } else {
             $requestData = $parameters;
             if ($this->isBinaryData($requestData)) {
                 $requestData = $this->binaryToDebugString($requestData);
             }
-            $this->debugSection("Request", "$method $url " . $requestData);
-            $this->response = (string)$this->connectionModule->_request($method, $url, [], $files, [], $parameters);
+            $this->debugSection("Request", sprintf('%s %s ', $method, $url) . $requestData);
+            $this->response = $this->connectionModule->_request($method, $url, [], $files, [], $parameters);
         }
         $printedResponse = $this->response;
-        if ($this->isBinaryData($printedResponse)) {
+        if ($this->isBinaryData((string) $printedResponse)) {
             $printedResponse = $this->binaryToDebugString($printedResponse);
         }
 
@@ -694,9 +719,9 @@ EOF;
      * Check if data has non-printable bytes and it is not a valid unicode string
      *
      * @param string $data the text or binary data string
-     * @return boolean
+     * @return bool
      */
-    protected function isBinaryData($data)
+    protected function isBinaryData(string $data): bool
     {
         return !ctype_print($data) && false === mb_detect_encoding($data, mb_detect_order(), true);
     }
@@ -707,7 +732,7 @@ EOF;
      * @param string $data the binary data string
      * @return string the debug string
      */
-    protected function binaryToDebugString($data)
+    protected function binaryToDebugString(string $data): string
     {
         return '[binary-data length:' . strlen($data) . ' md5:' . md5($data) . ']';
     }
@@ -717,19 +742,19 @@ EOF;
         if (
             array_key_exists('Content-Type', $this->connectionModule->headers)
             && ($this->connectionModule->headers['Content-Type'] === 'application/json'
-                || preg_match('!^application/.+\+json$!', $this->connectionModule->headers['Content-Type'])
+                || preg_match('#^application/.+\+json$#', $this->connectionModule->headers['Content-Type'])
             )
         ) {
-            if ($parameters instanceof \JsonSerializable) {
+            if ($parameters instanceof JsonSerializable) {
                 return json_encode($parameters);
             }
-            if (is_array($parameters) || $parameters instanceof \ArrayAccess) {
+            if (is_array($parameters) || $parameters instanceof ArrayAccess) {
                 $parameters = $this->scalarizeArray($parameters);
                 return json_encode($parameters);
             }
         }
 
-        if ($parameters instanceof \JsonSerializable) {
+        if ($parameters instanceof JsonSerializable) {
             throw new ModuleException(__CLASS__, $method . ' parameters is JsonSerializable object, but Content-Type header is not set to application/json');
         }
 
@@ -740,12 +765,11 @@ EOF;
         return $parameters;
     }
 
-    private function formatFilesArray(array $files)
+    private function formatFilesArray(array $files): array
     {
         foreach ($files as $name => $value) {
             if (is_string($value)) {
                 $this->checkFileBeforeUpload($value);
-
                 $files[$name] = [
                     'name' => basename($value),
                     'tmp_name' => $value,
@@ -754,7 +778,8 @@ EOF;
                     'error' => 0,
                 ];
                 continue;
-            } elseif (is_array($value)) {
+            }
+            if (is_array($value)) {
                 if (isset($value['tmp_name'])) {
                     $this->checkFileBeforeUpload($value['tmp_name']);
                     if (!isset($value['name'])) {
@@ -778,13 +803,16 @@ EOF;
                  * @issue https://github.com/Codeception/Codeception/issues/3298
                  */
             } else {
-                throw new ModuleException(__CLASS__, "Invalid value of key $name in files array");
+                throw new ModuleException(__CLASS__, sprintf('Invalid value of key %s in files array', $name));
             }
         }
 
         return $files;
     }
 
+    /**
+     * @return string|bool
+     */
     private function getFileType($file)
     {
         if (function_exists('mime_content_type') && mime_content_type($file)) {
@@ -793,16 +821,16 @@ EOF;
         return 'application/octet-stream';
     }
 
-    private function checkFileBeforeUpload($file)
+    private function checkFileBeforeUpload($file): void
     {
         if (!file_exists($file)) {
-            throw new ModuleException(__CLASS__, "File $file does not exist");
+            throw new ModuleException(__CLASS__, sprintf('File %s does not exist', $file));
         }
         if (!is_readable($file)) {
-            throw new ModuleException(__CLASS__, "File $file is not readable");
+            throw new ModuleException(__CLASS__, sprintf('File %s is not readable', $file));
         }
         if (!is_file($file)) {
-            throw new ModuleException(__CLASS__, "File $file is not a regular file");
+            throw new ModuleException(__CLASS__, sprintf('File %s is not a regular file', $file));
         }
     }
 
@@ -810,7 +838,7 @@ EOF;
      * Extends the function Module::validateConfig for shorten messages
      *
      */
-    protected function validateConfig()
+    protected function validateConfig(): void
     {
         parent::validateConfig();
 
@@ -829,35 +857,35 @@ EOF;
      *
      * @part json
      */
-    public function seeResponseIsJson()
+    public function seeResponseIsJson(): void
     {
         $responseContent = $this->connectionModule->_getResponseContent();
-        \PHPUnit\Framework\Assert::assertNotEquals('', $responseContent, 'response is empty');
+        Assert::assertNotEquals('', $responseContent, 'response is empty');
         $this->decodeAndValidateJson($responseContent);
     }
 
     /**
      * Checks whether the last response contains text.
      *
-     * @param $text
+     * @param string $text
      * @part json
      * @part xml
      */
-    public function seeResponseContains($text)
+    public function seeResponseContains(string $text): void
     {
-        $this->assertStringContainsString($text, $this->connectionModule->_getResponseContent(), "REST response contains");
+        $this->assertStringContainsString($text, $this->connectionModule->_getResponseContent(), 'REST response contains');
     }
 
     /**
      * Checks whether last response do not contain text.
      *
-     * @param $text
+     * @param string $text
      * @part json
      * @part xml
      */
-    public function dontSeeResponseContains($text)
+    public function dontSeeResponseContains(string $text): void
     {
-        $this->assertStringNotContainsString($text, $this->connectionModule->_getResponseContent(), "REST response contains");
+        $this->assertStringNotContainsString($text, $this->connectionModule->_getResponseContent(), 'REST response contains');
     }
 
     /**
@@ -876,7 +904,6 @@ EOF;
      * // response {user: john, profile: { email: john@gmail.com }}
      * $I->seeResponseContainsJson(array('email' => 'john@gmail.com'));
      *
-     * ?>
      * ```
      *
      * This method recursively checks if one array can be found inside of another.
@@ -884,9 +911,9 @@ EOF;
      * @param array $json
      * @part json
      */
-    public function seeResponseContainsJson($json = [])
+    public function seeResponseContainsJson(array $json = []): void
     {
-        \PHPUnit\Framework\Assert::assertThat(
+        Assert::assertThat(
             $this->connectionModule->_getResponseContent(),
             new JsonContains($json)
         );
@@ -914,30 +941,29 @@ EOF;
      * ];
      * $I->seeResponseIsValidOnJsonSchemaString(json_encode($schema));
      *
-     * ?>
      * ```
      *
      * @param string $schema
      * @part json
      */
-    public function seeResponseIsValidOnJsonSchemaString($schema)
+    public function seeResponseIsValidOnJsonSchemaString(string $schema): void
     {
         $responseContent = $this->connectionModule->_getResponseContent();
-        \PHPUnit\Framework\Assert::assertNotEquals('', $responseContent, 'response is empty');
+        Assert::assertNotEquals('', $responseContent, 'response is empty');
         $responseObject = $this->decodeAndValidateJson($responseContent);
 
-        \PHPUnit\Framework\Assert::assertNotEquals('', $schema, 'schema is empty');
+        Assert::assertNotEquals('', $schema, 'schema is empty');
         $schemaObject = $this->decodeAndValidateJson($schema, "Invalid schema json: %s. System message: %s.");
 
         $validator = new JsonSchemaValidator();
-        $validator->validate($responseObject, $schemaObject, JsonContraint::CHECK_MODE_VALIDATE_SCHEMA);
+        $validator->validate($responseObject, $schemaObject, JsonConstraint::CHECK_MODE_VALIDATE_SCHEMA);
         $outcome = $validator->isValid();
-        $error = "";
+        $error = '';
         if (!$outcome) {
             $errors = $validator->getErrors();
             $error = array_shift($errors)["message"];
         }
-        \PHPUnit\Framework\Assert::assertTrue(
+        Assert::assertTrue(
             $outcome,
             $error
         );
@@ -947,32 +973,31 @@ EOF;
      * Checks whether last response matches the supplied json schema (https://json-schema.org/)
      * Supply schema as relative file path in your project directory or an absolute path
      *
-     * @see codecept_absolute_path()
-     *
      * @param string $schemaFilename
      * @part json
+     * @see codecept_absolute_path()
      */
-    public function seeResponseIsValidOnJsonSchema($schemaFilename)
+    public function seeResponseIsValidOnJsonSchema(string $schemaFilename): void
     {
         $file = codecept_absolute_path($schemaFilename);
         if (!file_exists($file)) {
-            throw new ModuleException(__CLASS__, "File $file does not exist");
+            throw new ModuleException(__CLASS__, sprintf('File %s does not exist', $file));
         }
         $this->seeResponseIsValidOnJsonSchemaString(file_get_contents($file));
     }
 
     /**
-     * Converts string to json and asserts that no error occured while decoding.
+     * Converts string to json and asserts that no error occurred while decoding.
      *
      * @param string $jsonString the json encoded string
      * @param string $errorFormat optional string for custom sprintf format
      */
-    protected function decodeAndValidateJson($jsonString, $errorFormat="Invalid json: %s. System message: %s.")
+    protected function decodeAndValidateJson(string $jsonString, string $errorFormat="Invalid json: %s. System message: %s.")
     {
         $json = json_decode($jsonString);
         $errorCode = json_last_error();
         $errorMessage = json_last_error_msg();
-        \PHPUnit\Framework\Assert::assertEquals(
+        Assert::assertEquals(
             JSON_ERROR_NONE,
             $errorCode,
             sprintf(
@@ -993,14 +1018,13 @@ EOF;
      * <?php
      * $user_id = $I->grabResponse();
      * $I->sendPut('/user', array('id' => $user_id, 'name' => 'davert'));
-     * ?>
      * ```
      *
      * @return string
      * @part json
      * @part xml
      */
-    public function grabResponse()
+    public function grabResponse(): string
     {
         return $this->connectionModule->_getResponseContent();
     }
@@ -1015,15 +1039,14 @@ EOF;
      * // match the first `user.id` in json
      * $firstUserId = $I->grabDataFromResponseByJsonPath('$..users[0].id');
      * $I->sendPut('/user', array('id' => $firstUserId[0], 'name' => 'davert'));
-     * ?>
      * ```
      *
      * @param string $jsonPath
      * @return array Array of matching items
-     * @throws \Exception
+     * @throws Exception
      * @part json
      */
-    public function grabDataFromResponseByJsonPath($jsonPath)
+    public function grabDataFromResponseByJsonPath($jsonPath): array
     {
         return (new JsonArray($this->connectionModule->_getResponseContent()))->filterByJsonPath($jsonPath);
     }
@@ -1063,34 +1086,33 @@ EOF;
      * $I->seeResponseJsonMatchesXpath('//store/book[1]/author');
      * // at least one item in store has price
      * $I->seeResponseJsonMatchesXpath('/store//price');
-     * ?>
      * ```
-     * @param string $xpath
+     * @param string $xPath
      * @part json
      */
-    public function seeResponseJsonMatchesXpath($xpath)
+    public function seeResponseJsonMatchesXpath(string $xPath): void
     {
         $response = $this->connectionModule->_getResponseContent();
         $this->assertGreaterThan(
             0,
-            (new JsonArray($response))->filterByXPath($xpath)->length,
-            "Received JSON did not match the XPath `$xpath`.\nJson Response: \n" . $response
+            (new JsonArray($response))->filterByXPath($xPath)->length,
+            "Received JSON did not match the XPath `$xPath`.\nJson Response: \n" . $response
         );
     }
 
     /**
      * Opposite to seeResponseJsonMatchesXpath
      *
-     * @param string $xpath
+     * @param string $xPath
      * @part json
      */
-    public function dontSeeResponseJsonMatchesXpath($xpath)
+    public function dontSeeResponseJsonMatchesXpath(string $xPath): void
     {
         $response = $this->connectionModule->_getResponseContent();
         $this->assertEquals(
             0,
-            (new JsonArray($response))->filterByXPath($xpath)->length,
-            "Received JSON matched the XPath `$xpath`.\nJson Response: \n" . $response
+            (new JsonArray($response))->filterByXPath($xPath)->length,
+            "Received JSON matched the XPath `$xPath`.\nJson Response: \n" . $response
         );
     }
 
@@ -1128,13 +1150,12 @@ EOF;
      * $I->seeResponseJsonMatchesJsonPath('$.store.book[0].author');
      * // at least one item in store has price
      * $I->seeResponseJsonMatchesJsonPath('$.store..price');
-     * ?>
      * ```
      *
      * @param string $jsonPath
      * @part json
      */
-    public function seeResponseJsonMatchesJsonPath($jsonPath)
+    public function seeResponseJsonMatchesJsonPath(string $jsonPath): void
     {
         $response = $this->connectionModule->_getResponseContent();
         $this->assertNotEmpty(
@@ -1150,7 +1171,7 @@ EOF;
      * @param string $jsonPath
      * @part json
      */
-    public function dontSeeResponseJsonMatchesJsonPath($jsonPath)
+    public function dontSeeResponseJsonMatchesJsonPath(string $jsonPath): void
     {
         $response = $this->connectionModule->_getResponseContent();
         $this->assertEmpty(
@@ -1165,7 +1186,7 @@ EOF;
      * @part json
      * @param array $json
      */
-    public function dontSeeResponseContainsJson($json = [])
+    public function dontSeeResponseContainsJson(array $json = []): void
     {
         $jsonResponseArray = new JsonArray($this->connectionModule->_getResponseContent());
         $this->assertFalse(
@@ -1196,7 +1217,6 @@ EOF;
      * // narrow down matching with JsonPath:
      * // {"users": [{ "name": "davert"}, {"id": 1}]}
      * $I->seeResponseMatchesJsonType(['name' => 'string'], '$.users[0]');
-     * ?>
      * ```
      *
      * You can check if the record contains fields with the data types you expect.
@@ -1218,7 +1238,6 @@ EOF;
      *      'user_id' => 'integer|string', // multiple types
      *      'company' => ['name' => 'string']
      * ]);
-     * ?>
      * ```
      *
      * You can also apply filters to check values. Filter can be applied with a `:` char after the type declaration,
@@ -1247,25 +1266,23 @@ EOF;
      * $I->seeResponseMatchesJsonType([
      *      'user_id' => 'string:>0', // works with strings as well
      * ]);
-     * ?>
      * ```
      *
      * You can also add custom filters by using `{@link JsonType::addCustomFilter()}`.
      * See [JsonType reference](http://codeception.com/docs/reference/JsonType).
      *
      * @part json
-     * @param array $jsonType
-     * @param string $jsonPath
+     * @param string|null $jsonPath
      * @see JsonType
      */
-    public function seeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
+    public function seeResponseMatchesJsonType(array $jsonType, string $jsonPath = null): void
     {
         $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {
             $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
         }
 
-        \PHPUnit\Framework\Assert::assertThat($jsonArray, new JsonTypeConstraint($jsonType));
+        Assert::assertThat($jsonArray, new JsonTypeConstraint($jsonType));
     }
 
     /**
@@ -1273,17 +1290,17 @@ EOF;
      *
      * @part json
      * @param array $jsonType JsonType structure
-     * @param string $jsonPath
+     * @param string|null $jsonPath
      * @see seeResponseMatchesJsonType
      */
-    public function dontSeeResponseMatchesJsonType(array $jsonType, $jsonPath = null)
+    public function dontSeeResponseMatchesJsonType(array $jsonType, string $jsonPath = null): void
     {
         $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {
             $jsonArray = $jsonArray->filterByJsonPath($jsonPath);
         }
 
-        \PHPUnit\Framework\Assert::assertThat($jsonArray, new JsonTypeConstraint($jsonType, false));
+        Assert::assertThat($jsonArray, new JsonTypeConstraint($jsonType, false));
     }
 
     /**
@@ -1291,9 +1308,9 @@ EOF;
      *
      * @part json
      * @part xml
-     * @param $response
+     * @param $expected
      */
-    public function seeResponseEquals($expected)
+    public function seeResponseEquals($expected): void
     {
         $this->assertEquals($expected, $this->connectionModule->_getResponseContent());
     }
@@ -1313,7 +1330,7 @@ EOF;
      * @part xml
      * @param $code
      */
-    public function seeResponseCodeIs($code)
+    public function seeResponseCodeIs($code): void
     {
         $this->connectionModule->seeResponseCodeIs($code);
     }
@@ -1333,7 +1350,7 @@ EOF;
      * @part xml
      * @param $code
      */
-    public function dontSeeResponseCodeIs($code)
+    public function dontSeeResponseCodeIs($code): void
     {
         $this->connectionModule->dontSeeResponseCodeIs($code);
     }
@@ -1344,7 +1361,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function seeResponseCodeIsSuccessful()
+    public function seeResponseCodeIsSuccessful(): void
     {
         $this->connectionModule->seeResponseCodeIsSuccessful();
     }
@@ -1355,7 +1372,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function seeResponseCodeIsRedirection()
+    public function seeResponseCodeIsRedirection(): void
     {
         $this->connectionModule->seeResponseCodeIsRedirection();
     }
@@ -1366,7 +1383,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function seeResponseCodeIsClientError()
+    public function seeResponseCodeIsClientError(): void
     {
         $this->connectionModule->seeResponseCodeIsClientError();
     }
@@ -1377,7 +1394,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function seeResponseCodeIsServerError()
+    public function seeResponseCodeIsServerError(): void
     {
         $this->connectionModule->seeResponseCodeIsServerError();
     }
@@ -1389,12 +1406,12 @@ EOF;
      *
      * @part xml
      */
-    public function seeResponseIsXml()
+    public function seeResponseIsXml(): void
     {
         libxml_use_internal_errors(true);
         $doc = simplexml_load_string($this->connectionModule->_getResponseContent());
-        $num = "";
-        $title = "";
+        $num = '';
+        $title = '';
         if ($doc === false) {
             $error = libxml_get_last_error();
             $num = $error->code;
@@ -1402,10 +1419,10 @@ EOF;
             libxml_clear_errors();
         }
         libxml_use_internal_errors(false);
-        \PHPUnit\Framework\Assert::assertNotSame(
+        Assert::assertNotSame(
             false,
             $doc,
-            "xml decoding error #$num with message \"$title\", see http://www.xmlsoft.org/html/libxml-xmlerror.html"
+            sprintf('xml decoding error #%s with message "%s".', $num, $title)
         );
     }
 
@@ -1417,12 +1434,12 @@ EOF;
      * $I->seeXmlResponseMatchesXpath('//root/user[@id=1]');
      * ```
      * @part xml
-     * @param $xpath
+     * @param $xPath
      */
-    public function seeXmlResponseMatchesXpath($xpath)
+    public function seeXmlResponseMatchesXpath($xPath): void
     {
-        $structure = new XmlStructure($this->connectionModule->_getResponseContent());
-        $this->assertTrue($structure->matchesXpath($xpath), 'xpath not matched');
+        $xmlStructure = new XmlStructure($this->connectionModule->_getResponseContent());
+        $this->assertTrue($xmlStructure->matchesXpath($xPath), 'xpath not matched');
     }
 
     /**
@@ -1433,12 +1450,12 @@ EOF;
      * $I->dontSeeXmlResponseMatchesXpath('//root/user[@id=1]');
      * ```
      * @part xml
-     * @param $xpath
+     * @param $xPath
      */
-    public function dontSeeXmlResponseMatchesXpath($xpath)
+    public function dontSeeXmlResponseMatchesXpath($xPath): void
     {
         $structure = new XmlStructure($this->connectionModule->_getResponseContent());
-        $this->assertFalse($structure->matchesXpath($xpath), 'accidentally matched xpath');
+        $this->assertFalse($structure->matchesXpath($xPath), 'accidentally matched xpath');
     }
 
     /**
@@ -1449,7 +1466,7 @@ EOF;
      * @return string
      * @part xml
      */
-    public function grabTextContentFromXmlElement($cssOrXPath)
+    public function grabTextContentFromXmlElement($cssOrXPath): string
     {
         $el = (new XmlStructure($this->connectionModule->_getResponseContent()))->matchElement($cssOrXPath);
         return $el->textContent;
@@ -1464,11 +1481,11 @@ EOF;
      * @return string
      * @part xml
      */
-    public function grabAttributeFromXmlElement($cssOrXPath, $attribute)
+    public function grabAttributeFromXmlElement(string $cssOrXPath, $attribute): string
     {
         $el = (new XmlStructure($this->connectionModule->_getResponseContent()))->matchElement($cssOrXPath);
         if (!$el->hasAttribute($attribute)) {
-            $this->fail("Attribute not found in element matched by '$cssOrXPath'");
+            $this->fail(sprintf('Attribute not found in element matched by \'%s\'', $cssOrXPath));
         }
         return $el->getAttribute($attribute);
     }
@@ -1482,9 +1499,9 @@ EOF;
      * @param $xml
      * @part xml
      */
-    public function seeXmlResponseEquals($xml)
+    public function seeXmlResponseEquals($xml): void
     {
-        \PHPUnit\Framework\Assert::assertXmlStringEqualsXmlString($this->connectionModule->_getResponseContent(), $xml);
+        Assert::assertXmlStringEqualsXmlString($this->connectionModule->_getResponseContent(), $xml);
     }
 
 
@@ -1497,9 +1514,9 @@ EOF;
      * @param $xml
      * @part xml
      */
-    public function dontSeeXmlResponseEquals($xml)
+    public function dontSeeXmlResponseEquals($xml): void
     {
-        \PHPUnit\Framework\Assert::assertXmlStringNotEqualsXmlString(
+        Assert::assertXmlStringNotEqualsXmlString(
             $this->connectionModule->_getResponseContent(),
             $xml
         );
@@ -1515,13 +1532,12 @@ EOF;
      * ``` php
      * <?php
      * $I->seeXmlResponseIncludes("<result>1</result>");
-     * ?>
      * ```
      *
      * @param $xml
      * @part xml
      */
-    public function seeXmlResponseIncludes($xml)
+    public function seeXmlResponseIncludes($xml): void
     {
         $this->assertStringContainsString(
             XmlUtils::toXml($xml)->C14N(),
@@ -1538,7 +1554,7 @@ EOF;
      * @param $xml
      * @part xml
      */
-    public function dontSeeXmlResponseIncludes($xml)
+    public function dontSeeXmlResponseIncludes($xml): void
     {
         $this->assertStringNotContainsString(
             XmlUtils::toXml($xml)->C14N(),
@@ -1557,7 +1573,6 @@ EOF;
      * ```php
      * <?php
      * $I->seeBinaryResponseEquals("8c90748342f19b195b9c6b4eff742ded");
-     * ?>
      * ```
      *
      * Example: Using md5 for a file contents
@@ -1566,7 +1581,6 @@ EOF;
      * <?php
      * $fileData = file_get_contents("test_file.jpg");
      * $I->seeBinaryResponseEquals(md5($fileData));
-     * ?>
      * ```
      * Example: Using sha256 hash
      *
@@ -1574,7 +1588,6 @@ EOF;
      * <?php
      * $fileData = '/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k='; // very small jpeg
      * $I->seeBinaryResponseEquals(hash("sha256", base64_decode($fileData)), 'sha256');
-     * ?>
      * ```
      *
      * @param string $hash the hashed data response expected
@@ -1582,7 +1595,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function seeBinaryResponseEquals($hash, $algo = 'md5')
+    public function seeBinaryResponseEquals(string $hash, string $algo = 'sha1'): void
     {
         $responseHash = hash($algo, $this->connectionModule->_getResponseContent());
         $this->assertEquals($hash, $responseHash);
@@ -1594,7 +1607,6 @@ EOF;
      * ```php
      * <?php
      * $I->dontSeeBinaryResponseEquals("8c90748342f19b195b9c6b4eff742ded");
-     * ?>
      * ```
      * Opposite to `seeBinaryResponseEquals`
      *
@@ -1603,7 +1615,7 @@ EOF;
      * @part json
      * @part xml
      */
-    public function dontSeeBinaryResponseEquals($hash, $algo = 'md5')
+    public function dontSeeBinaryResponseEquals(string $hash, string $algo = 'sha1'): void
     {
         $responseHash = hash($algo, $this->connectionModule->_getResponseContent());
         $this->assertNotEquals($hash, $responseHash);
@@ -1620,7 +1632,7 @@ EOF;
      * @part xml
      * @part json
      */
-    public function stopFollowingRedirects()
+    public function stopFollowingRedirects(): void
     {
         $this->client->followRedirects(false);
     }
@@ -1636,7 +1648,7 @@ EOF;
      * @part xml
      * @part json
      */
-    public function startFollowingRedirects()
+    public function startFollowingRedirects(): void
     {
         $this->client->followRedirects(true);
     }
@@ -1649,7 +1661,7 @@ EOF;
      * $I->setServerParameters([]);
      * ```
      */
-    public function setServerParameters(array $params)
+    public function setServerParameters(array $params): void
     {
         $this->client->setServerParameters($params);
     }
@@ -1661,7 +1673,7 @@ EOF;
      * $I->haveServerParameter('name', 'value');
      * ```
      */
-    public function haveServerParameter($name, $value)
+    public function haveServerParameter($name, $value): void
     {
         $this->client->setServerParameter($name, $value);
     }

--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -79,10 +79,10 @@ class JsonArray
         return $this->jsonArray;
     }
 
-    public function filterByXPath($xpath)
+    public function filterByXPath(string $xPath)
     {
         $path = new DOMXPath($this->toXml());
-        return $path->query($xpath);
+        return $path->query($xPath);
     }
 
     public function filterByJsonPath($jsonPath): array

--- a/src/Codeception/Util/JsonArray.php
+++ b/src/Codeception/Util/JsonArray.php
@@ -1,9 +1,15 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
+use Exception;
 use Flow\JSONPath\JSONPath;
 use InvalidArgumentException;
-use DOMDocument;
 
 class JsonArray
 {
@@ -15,7 +21,7 @@ class JsonArray
     /**
      * @var DOMDocument
      */
-    protected $jsonXml = null;
+    protected $jsonXml;
 
     public function __construct($jsonString)
     {
@@ -43,7 +49,7 @@ class JsonArray
         }
     }
 
-    public function toXml()
+    public function toXml(): DOMDocument
     {
         if ($this->jsonXml) {
             return $this->jsonXml;
@@ -68,24 +74,21 @@ class JsonArray
         return $dom;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->jsonArray;
     }
 
     public function filterByXPath($xpath)
     {
-        $path = new \DOMXPath($this->toXml());
+        $path = new DOMXPath($this->toXml());
         return $path->query($xpath);
     }
 
-    public function filterByJsonPath($jsonPath)
+    public function filterByJsonPath($jsonPath): array
     {
-        if (!class_exists('Flow\JSONPath\JSONPath')) {
-            throw new \Exception('JSONPath library not installed. Please add `softcreatr/jsonpath` to composer.json');
+        if (!class_exists(\Flow\JSONPath\JSONPath::class)) {
+            throw new Exception('JSONPath library not installed. Please add `softcreatr/jsonpath` to composer.json');
         }
         return (new JSONPath($this->jsonArray))->find($jsonPath)->getData();
     }
@@ -95,12 +98,12 @@ class JsonArray
         return $this->toXml()->saveXML();
     }
 
-    public function containsArray(array $needle)
+    public function containsArray(array $needle): bool
     {
         return (new ArrayContainsComparator($this->jsonArray))->containsArray($needle);
     }
 
-    private function arrayToXml(\DOMDocument $doc, \DOMNode $node, $array)
+    private function arrayToXml(DOMDocument $doc, DOMNode $node, $array)
     {
         foreach ($array as $key => $value) {
             if (is_numeric($key)) {
@@ -109,7 +112,7 @@ class JsonArray
             } else {
                 try {
                     $subNode = $doc->createElement($key);
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $key = $this->getValidTagNameForInvalidKey($key);
                     $subNode = $doc->createElement($key);
                 }

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -31,6 +31,9 @@ namespace Codeception\Util;
  */
 class JsonType
 {
+    /**
+     * @var array|JsonArray
+     */
     protected $jsonArray;
 
     /**
@@ -72,12 +75,10 @@ class JsonType
      *   return strlen($value) == $len;
      * });
      * // use it as 'string:len(5)'
-     * ?>
      * ```
      *
-     * @param          $name
      */
-    public static function addCustomFilter($name, callable $callable)
+    public static function addCustomFilter(string $name, callable $callable)
     {
         static::$customFilters[$name] = $callable;
     }
@@ -119,7 +120,7 @@ class JsonType
     /**
      * @return string|bool
      */
-    protected function typeComparison($data, $jsonType)
+    protected function typeComparison(array $data, array $jsonType)
     {
         foreach ($jsonType as $key => $type) {
             if (!array_key_exists($key, $data)) {
@@ -190,7 +191,7 @@ class JsonType
         return true;
     }
 
-    protected function matchFilter($filter, string $value)
+    protected function matchFilter(string $filter, string $value)
     {
         $filter = trim($filter);
         if (strpos($filter, '!') === 0) {

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 /**
@@ -31,6 +33,9 @@ class JsonType
 {
     protected $jsonArray;
 
+    /**
+     * @var array
+     */
     protected static $customFilters = [];
 
     /**
@@ -38,7 +43,7 @@ class JsonType
      * Pass an array or `\Codeception\Util\JsonArray` with data.
      * If non-associative array is passed - the very first element of it will be used for matching.
      *
-     * @param $jsonArray array|\Codeception\Util\JsonArray
+     * @param $jsonArray array|JsonArray
      */
     public function __construct($jsonArray)
     {
@@ -71,7 +76,6 @@ class JsonType
      * ```
      *
      * @param          $name
-     * @param callable $callable
      */
     public static function addCustomFilter($name, callable $callable)
     {
@@ -91,21 +95,20 @@ class JsonType
      * If matching fails function returns a string with a message describing failure.
      * On success returns `true`.
      *
-     * @param array $jsonType
-     * @return bool|string
+     * @return string|bool
      */
     public function matches(array $jsonType)
     {
         if (array_key_exists(0, $this->jsonArray) && is_array($this->jsonArray[0])) {
             // a list of items
             $msg = '';
-            foreach ($this->jsonArray as $array) {
-                $res = $this->typeComparison($array, $jsonType);
+            foreach ($this->jsonArray as $singleJsonArray) {
+                $res = $this->typeComparison($singleJsonArray, $jsonType);
                 if ($res !== true) {
                     $msg .= "\n" . $res;
                 }
             }
-            if ($msg) {
+            if ($msg !== '') {
                 return $msg;
             }
             return true;
@@ -113,6 +116,9 @@ class JsonType
         return $this->typeComparison($this->jsonArray, $jsonType);
     }
 
+    /**
+     * @return string|bool
+     */
     protected function typeComparison($data, $jsonType)
     {
         foreach ($jsonType as $key => $type) {
@@ -163,13 +169,13 @@ class JsonType
 
                 foreach ($filters as $filter) {
                     // Fill regex pattern back into the filter.
-                    $filter = preg_replace_callback('/\$\$\d+/', function ($m) use ($regexes) {
+                    $filter = preg_replace_callback('#\$\$\d+#', function ($m) use ($regexes) {
                         $pos = (int)substr($m[0], 2);
 
                         return $regexes[1][$pos];
                     }, $filter);
 
-                    $matched = $matched && $this->matchFilter($filter, $data[$key]);
+                    $matched = $matched && $this->matchFilter($filter, (string) $data[$key]);
                 }
 
                 if ($matched) {
@@ -184,7 +190,7 @@ class JsonType
         return true;
     }
 
-    protected function matchFilter($filter, $value)
+    protected function matchFilter($filter, string $value)
     {
         $filter = trim($filter);
         if (strpos($filter, '!') === 0) {
@@ -193,11 +199,9 @@ class JsonType
 
         // apply custom filters
         foreach (static::$customFilters as $customFilter => $callable) {
-            if (strpos($customFilter, '/') === 0) {
-                if (preg_match($customFilter, $filter, $matches)) {
-                    array_shift($matches);
-                    return call_user_func_array($callable, array_merge([$value], $matches));
-                }
+            if (strpos($customFilter, '/') === 0 && preg_match($customFilter, $filter, $matches)) {
+                array_shift($matches);
+                return call_user_func_array($callable, array_merge([$value], $matches));
             }
             if ($customFilter == $filter) {
                 return $callable($value);
@@ -212,32 +216,32 @@ class JsonType
         }
         if ($filter === 'date') {
             return preg_match(
-                '/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(?:Z|(\+|-)([\d|:]*))?$/',
+                '#^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d+)?(?:Z|(\+|-)([\d|:]*))?$#',
                 $value
             );
         }
         if ($filter === 'email') { // from http://emailregex.com/
             // @codingStandardsIgnoreStart
-            return preg_match('/^(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){255,})(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){65,}@)(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|(?:\x5C[\x00-\x7F]))*\x22))(?:\.(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|(?:\x5C[\x00-\x7F]))*\x22)))*@(?:(?:(?!.*[^.]{64,})(?:(?:(?:xn--)?[a-z0-9]+(?:-[a-z0-9]+)*\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-[a-z0-9]+)*)|(?:\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))(?:\.(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))){3}))\]))$/iD',
+            return preg_match('#^(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){255,})(?!(?:(?:\x22?\x5C[\x00-\x7E]\x22?)|(?:\x22?[^\x5C\x22]\x22?)){65,}@)(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|(?:\x5C[\x00-\x7F]))*\x22))(?:\.(?:(?:[\x21\x23-\x27\x2A\x2B\x2D\x2F-\x39\x3D\x3F\x5E-\x7E]+)|(?:\x22(?:[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F]|(?:\x5C[\x00-\x7F]))*\x22)))*@(?:(?:(?!.*[^.]{64,})(?:(?:(?:xn--)?[a-z0-9]+(?:-[a-z0-9]+)*\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-[a-z0-9]+)*)|(?:\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4]\d)|(?:1\d{2})|(?:[1-9]?\d))(?:\.(?:(?:25[0-5])|(?:2[0-4]\d)|(?:1\d{2})|(?:[1-9]?\d))){3}))\]))$#iD',
                 $value);
             // @codingStandardsIgnoreEnd
         }
         if ($filter === 'empty') {
             return empty($value);
         }
-        if (preg_match('~^regex\((.*?)\)$~', $filter, $matches)) {
+        if (preg_match('#^regex\((.*?)\)$#', $filter, $matches)) {
             return preg_match($matches[1], $value);
         }
-        if (preg_match('~^>=(-?[\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('#^>=(-?[\d\.]+)$#', $filter, $matches)) {
             return (float)$value >= (float)$matches[1];
         }
-        if (preg_match('~^<=(-?[\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('#^<=(-?[\d\.]+)$#', $filter, $matches)) {
             return (float)$value <= (float)$matches[1];
         }
-        if (preg_match('~^>(-?[\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('#^>(-?[\d\.]+)$#', $filter, $matches)) {
             return (float)$value > (float)$matches[1];
         }
-        if (preg_match('~^<(-?[\d\.]+)$~', $filter, $matches)) {
+        if (preg_match('#^<(-?[\d\.]+)$#', $filter, $matches)) {
             return (float)$value < (float)$matches[1];
         }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -322,7 +322,7 @@ final class RestTest extends Unit
 
     public function testThrowsExceptionIfUrlIsNotString()
     {
-        $this->expectExceptionMessage('URL must be string');
+        $this->expectException(TypeError::class);
         $this->module->sendPOST([1]);
     }
 

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Configuration;
 use Codeception\Example;
 use Codeception\Module\UniversalFramework;
@@ -10,7 +12,7 @@ use Codeception\Util\Stub;
  * Class RestTest
  * @group appveyor
  */
-class RestTest extends Unit
+final class RestTest extends Unit
 {
     /**
      * @var \Codeception\Module\REST
@@ -551,7 +553,7 @@ class RestTest extends Unit
     {
         $data = base64_decode('/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=');
         $this->setStubResponse($data);
-        $this->module->seeBinaryResponseEquals(md5($data));
+        $this->module->seeBinaryResponseEquals(sha1($data));
     }
 
     public function testDontSeeBinaryResponseEquals()

--- a/tests/unit/Codeception/Util/JsonArrayTest.php
+++ b/tests/unit/Codeception/Util/JsonArrayTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
 class JsonArrayTest extends \Codeception\Test\Unit

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -1,7 +1,10 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Util;
 
-class JsonTypeTest extends \Codeception\Test\Unit
+final class JsonTypeTest extends \Codeception\Test\Unit
 {
     protected $types = [
         'id' => 'integer:>10',


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added some typehints
- Removed unnecessary qualifiers
- `#` as PREG delimiter
- Fix naming and typos
- sha1 by default instead of md5.