### PR TITLE
Add a failing test for JsonType assert

### DIFF
--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -493,6 +493,21 @@ class RestTest extends Unit
         $this->module->dontSeeResponseMatchesJsonType(['id' => 'integer'], '$.users[0]');
     }
 
+    public function testJsonTypeMatchesWithJsonPathAndPotentiallyEmptyArrays()
+    {
+        // Passes when all users have non-empty roles.
+        $this->setStubResponse('{"users": [{"id": 1, "roles": [{"name": "admin"}]}]}');
+        $this->module->seeResponseMatchesJsonType(['name' => 'string'], '$.users.*.roles.*');
+
+        // Passes when at least one user has non-empty roles.
+        $this->setStubResponse('{"users": [{"id": 1, "roles": [{"name": "admin"}]}, {"id": 2, "roles": []}]}');
+        $this->module->seeResponseMatchesJsonType(['name' => 'string'], '$.users.*.roles.*');
+
+        // Fails when all users have empty roles.
+        $this->setStubResponse('{"users": [{"id": 1, "roles": []}]}');
+        $this->module->seeResponseMatchesJsonType(['name' => 'string'], '$.users.*.roles.*');
+    }
+
     public function testMatchJsonTypeFailsWithNiceMessage()
     {
         $this->setStubResponse('{"xxx": "yyy", "user_id": 1}');


### PR DESCRIPTION
I believe the `seeResponseMatchesJsonType()` assert is broken and I've added a failing test to illustrate this.

We are going to test the same assert against different JSON documents. The assert is
```php
seeResponseMatchesJsonType(['name' => 'string'], '$.users.*.roles.*');
```


The first document has matching `roles` arrays for all users and the assert passes:
```json
{
  "users": [
    {
      "id": 1,
      "roles": [
        {
          "name": "admin"
        }
      ]
    }
  ]
}
```