### PR TITLE
Add JSON_PRESERVE_ZERO_FRACTION flag

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -663,7 +663,7 @@ EOF;
                 $this->debugSection("Request", "$method $url");
                 $files = [];
             } else {
-                $this->debugSection("Request", "$method $url " . json_encode($parameters));
+                $this->debugSection("Request", "$method $url " . json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION));
                 $files = $this->formatFilesArray($files);
             }
             $this->response = (string)$this->connectionModule->_request($method, $url, $parameters, $files);
@@ -721,11 +721,11 @@ EOF;
             )
         ) {
             if ($parameters instanceof \JsonSerializable) {
-                return json_encode($parameters);
+                return json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION);
             }
             if (is_array($parameters) || $parameters instanceof \ArrayAccess) {
                 $parameters = $this->scalarizeArray($parameters);
-                return json_encode($parameters);
+                return json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION);
             }
         }
 


### PR DESCRIPTION
The native `json_encode` method trims trailing zeros after the decimal point, which can be a problem.

For example typed properties in PHP7.4 they can expect float (e.g. product price), but receive int, which triggers a runtime error.