### PR TITLE
Fixing namespace issue

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -541,7 +541,7 @@ EOF;
      * $response = $I->sendPatch('/message/1', ['subject' => 'Read this!']);
      * ```
      *
-     * @param array|string|JsonSerializable $params
+     * @param array|string|\JsonSerializable $params
      * @part json
      * @part xml
      */


### PR DESCRIPTION
The line `use JsonSerializable;` of this file is not being passed on to `tests/Support/_generated/AcceptanceTesterActions.php`. And with the current phpDoc
```php
@param array|string|JsonSerializable $params
```
... phpstan is correctly reporting:
> Parameter #2 $params of method Tests\Support\AcceptanceTester::sendPatch() expects array|string|Tests\Support\_generated\JsonSerializable ...

So the question is: Is there a way to include the needed `use`s in the generated `TesterAction`s? Or should all occurrences of such "root" classes in the code get prefixed with a `\`?