### PR TITLE
Allow softcreatr/jsonpath v0.9 + justinrainbow/json-schema v5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/codeception": "^5.0.8",
         "codeception/lib-xml": "^1.0",
         "justinrainbow/json-schema": "~5.2.9",
-        "softcreatr/jsonpath": "^0.8"
+        "softcreatr/jsonpath": "^0.8 || ^0.9"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "codeception/codeception": "^5.0.8",
         "codeception/lib-xml": "^1.0",
-        "justinrainbow/json-schema": "~5.2.9",
+        "justinrainbow/json-schema": "^5.2.9",
         "softcreatr/jsonpath": "^0.8 || ^0.9"
     },
     "require-dev": {


### PR DESCRIPTION
According to https://github.com/SoftCreatR/JSONPath/blob/main/CHANGELOG.md#090 dropping support for PHP < 8.1 is the only "breaking change" compared to v0.8.