### PR TITLE
Test against PHP 8.2 + 8.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [8.0, 8.1, 8.2, 8.3]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "homepage": "https://codeception.com/",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-dom": "*",
         "ext-json": "*",
         "codeception/codeception": "^5.0.8",

--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1330,7 +1330,7 @@ EOF;
      * @part json
      * @see JsonType
      */
-    public function seeResponseMatchesJsonType(array $jsonType, string $jsonPath = null): void
+    public function seeResponseMatchesJsonType(array $jsonType, ?string $jsonPath = null): void
     {
         $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {
@@ -1347,7 +1347,7 @@ EOF;
      * @param array $jsonType JsonType structure
      * @see seeResponseMatchesJsonType
      */
-    public function dontSeeResponseMatchesJsonType(array $jsonType, string $jsonPath = null): void
+    public function dontSeeResponseMatchesJsonType(array $jsonType, ?string $jsonPath = null): void
     {
         $jsonArray = new JsonArray($this->connectionModule->_getResponseContent());
         if ($jsonPath) {

--- a/src/Codeception/Step/AsJson.php
+++ b/src/Codeception/Step/AsJson.php
@@ -7,7 +7,7 @@ use Codeception\Util\Template;
 
 class AsJson extends Action implements GeneratedStep
 {
-    public function run(ModuleContainer $container = null)
+    public function run(?ModuleContainer $container = null)
     {
         $container->getModule('REST')->haveHttpHeader('Content-Type', 'application/json');
         $resp = parent::run($container);


### PR DESCRIPTION
Furthermore, nullable parameter types are defined explicitly because not doing that will be deprecated in PHP 8.4: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types