### PR TITLE
Add Accept: application/json header to AsJson step

### DIFF
--- a/src/Codeception/Step/AsJson.php
+++ b/src/Codeception/Step/AsJson.php
@@ -9,6 +9,7 @@ class AsJson extends Action implements GeneratedStep
 {
     public function run(ModuleContainer $container = null)
     {
+        $container->getModule('REST')->haveHttpHeader('Accept', 'application/json');
         $container->getModule('REST')->haveHttpHeader('Content-Type', 'application/json');
         $resp = parent::run($container);
         $container->getModule('REST')->seeResponseIsJson();


### PR DESCRIPTION
Adding this header will make it easier to read exceptions in the console, e.g. in Symfony currently html is returned.