### PR TITLE
Relax parameter types to allow filters like "array:empty" in JsonType

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -1301,6 +1301,7 @@ EOF;
      *
      * Here is the list of possible filters:
      *
+     * * `array:empty` - check that value is an empty array
      * * `integer:>{val}` - checks that integer is greater than {val} (works with float and string types too).
      * * `integer:<{val}` - checks that integer is lower than {val} (works with float and string types too).
      * * `string:url` - checks that value is valid url.

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -170,7 +170,7 @@ class JsonType
                         return $regexes[1][$pos];
                     }, $filter);
 
-                    $matched = $matched && $this->matchFilter($filter, (string)$data[$key]);
+                    $matched = $matched && $this->matchFilter($filter, $data[$key]);
                 }
 
                 if ($matched) {
@@ -186,7 +186,7 @@ class JsonType
         return true;
     }
 
-    protected function matchFilter(string $filter, string $value)
+    protected function matchFilter(string $filter, mixed $value)
     {
         $filter = trim($filter);
         if (str_starts_with($filter, '!')) {
@@ -206,7 +206,7 @@ class JsonType
         }
 
         if (str_starts_with($filter, '=')) {
-            return $value === substr($filter, 1);
+            return (string) $value === substr($filter, 1);
         }
 
         if ($filter === 'url') {
@@ -232,7 +232,7 @@ class JsonType
         }
 
         if (preg_match('#^regex\((.*?)\)$#', $filter, $matches)) {
-            return preg_match($matches[1], $value);
+            return preg_match($matches[1], (string) $value);
         }
 
         if (preg_match('#^>=(-?[\d\.]+)$#', $filter, $matches)) {

--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -14,10 +14,11 @@ namespace Codeception\Util;
  *
  * ```php
  * <?php
- * $jsonType = new JsonType(['name' => 'davert', 'id' => 1]);
+ * $jsonType = new JsonType(['name' => 'davert', 'id' => 1, 'data' => []]);
  * $jsonType->matches([
  *   'name' => 'string:!empty',
  *   'id' => 'integer:>0|string:>0',
+ *   'data' => 'array:empty',
  * ]); // => true
  *
  * $jsonType->matches([

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -500,9 +500,10 @@ final class RestTest extends Unit
 
     public function testJsonTypeMatches()
     {
-        $this->setStubResponse('{"xxx": "yyy", "user_id": 1}');
-        $this->module->seeResponseMatchesJsonType(['xxx' => 'string', 'user_id' => 'integer:<10']);
-        $this->module->dontSeeResponseMatchesJsonType(['xxx' => 'integer', 'user_id' => 'integer:<10']);
+        $this->setStubResponse('{"xxx": "yyy", "user_id": 1, "empty_array": [], "non_empty_array": ["foo"]}');
+        $this->module->seeResponseMatchesJsonType(['xxx' => 'string', 'user_id' => 'integer:<10', 'empty_array' => 'array:empty', 'non_empty_array' => 'array:!empty']);
+        $this->module->dontSeeResponseMatchesJsonType(['xxx' => 'integer', 'user_id' => 'integer:<10', 'empty_array' => 'array:empty', 'non_empty_array' => 'array:!empty']);
+        $this->module->dontSeeResponseMatchesJsonType(['xxx' => 'string', 'user_id' => 'integer:<10', 'empty_array' => 'array:!empty', 'non_empty_array' => 'array:!empty']);
     }
 
     public function testJsonTypeMatchesWithJsonPath()

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -15,7 +15,8 @@ final class JsonTypeTest extends Unit
         'name' => 'string|null', // http://codeception.com/docs/modules/REST#seeResponseMatchesJsonType
         'user' => [
             'url' => 'String:url'
-        ]
+        ],
+        'empty_array' => 'array',
     ];
 
     protected array $data = [
@@ -23,7 +24,8 @@ final class JsonTypeTest extends Unit
         'retweeted' => false,
         'in_reply_to_screen_name' => null,
         'name' => null,
-        'user' => ['url' => 'http://davert.com']
+        'user' => ['url' => 'http://davert.com'],
+        'empty_array' => [],
     ];
 
     protected function _after()
@@ -167,6 +169,7 @@ final class JsonTypeTest extends Unit
         $this->types['user'] = 'array';
         $jsonType = new JsonType($this->data);
         $this->assertTrue($jsonType->matches($this->types));
+        $this->assertTrue($jsonType->matches(['empty_array' => 'array:empty']));
     }
 
     public function testNull()

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -170,6 +170,7 @@ final class JsonTypeTest extends Unit
         $jsonType = new JsonType($this->data);
         $this->assertTrue($jsonType->matches($this->types));
         $this->assertTrue($jsonType->matches(['empty_array' => 'array:empty']));
+        $this->assertTrue($jsonType->matches(['empty_array' => 'Array:empty']));
     }
 
     public function testNull()

--- a/tests/unit/Codeception/Util/JsonTypeTest.php
+++ b/tests/unit/Codeception/Util/JsonTypeTest.php
@@ -137,10 +137,11 @@ final class JsonTypeTest extends Unit
 
     public function testNegativeFilters()
     {
-        $jsonType = new JsonType(['name' => 'davert', 'id' => 1]);
+        $jsonType = new JsonType(['name' => 'davert', 'id' => 1, 'data' => ['foo']]);
         $this->assertTrue($jsonType->matches([
             'name' => 'string:!date|string:!empty',
             'id' => 'integer:!=0',
+            'data' => 'array:!empty',
         ]));
     }
 


### PR DESCRIPTION
Fixes https://github.com/Codeception/module-rest/issues/100