### PR TITLE
PHP 8.4: Avoid usage of the deprecated E_STRICT constant

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,5 +1,5 @@
 # Codeception Test Suite Configuration
 
 # suite for unit (internal) tests.
-error_level: "E_ALL | E_STRICT"
+error_level: "E_ALL"
 class_name: UnitTester


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant