### PR TITLE
Fix tests for PHPUnit 12

### DIFF
--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -697,18 +697,16 @@ final class RestTest extends Unit
         $connectionModule
             ->expects($this->once())
             ->method('_request')
-            ->will(
-                $this->returnCallback(function($method,
-                    $uri,
-                    $parameters,
-                    $files,
-                    $server,
-                    $content
-                ) use ($expectedFullUrl) {
-                    Assert::assertSame($expectedFullUrl, $uri);
-                    return '';
-                })
-            );
+            ->willReturnCallback(function($method,
+                $uri,
+                $parameters,
+                $files,
+                $server,
+                $content
+            ) use ($expectedFullUrl) {
+                Assert::assertSame($expectedFullUrl, $uri);
+                return '';
+            });
 
         $config = ['url' => $configUrl];
 


### PR DESCRIPTION
`TestCase::returnCallback()` was deprecated in PHPUnit 11 and removed in PHPUnit 12 (see https://github.com/sebastianbergmann/phpunit/issues/5423).