### PR TITLE
Allow softcreatr/jsonpath v0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/codeception": "^5.0.8",
         "codeception/lib-xml": "^1.0",
         "justinrainbow/json-schema": "^5.2.9 || ^6",
-        "softcreatr/jsonpath": "^0.8 || ^0.9"
+        "softcreatr/jsonpath": "^0.8 || ^0.9 || ^0.10"
     },
     "require-dev": {
         "ext-libxml": "*",


### PR DESCRIPTION
Changelog: https://github.com/SoftCreatR/JSONPath/releases/tag/0.10.0

Seems like this package is not affected by the latest changes.