### PR TITLE
Add grabHttpHeaders() to return all response http headers

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -201,6 +201,23 @@ EOF;
     }
 
     /**
+     * Returns all HTTP headers from the last response.
+     *
+     * ```php
+     * <?php
+     * $I->sendGet('/message/1');
+     * $headers = $I->grabHttpHeaders();
+     * ```
+     *
+     * @part json
+     * @part xml
+     */
+    public function grabHttpHeaders(): array
+    {
+        return $this->getRunningClient()->getInternalResponse()->getHeaders();
+    }
+
+    /**
      * Sets a HTTP header to be used for all subsequent requests. Use [`unsetHttpHeader`](#unsetHttpHeader) to unset it.
      *
      * ```php

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -368,6 +368,18 @@ final class RestTest extends Unit
         $this->assertSame('http://localhost/api/v1/users', $request->getUri());
     }
 
+    public function testGrabHttpHeaders()
+    {
+        $headers = [
+            'Cache-Control' => ['no-cache', 'no-store'],
+            'Content_Language' => 'en-US'
+        ];
+        $response = new SymfonyResponse("", 200, $headers);
+        $this->module->client->mockResponse($response);
+        $this->module->sendGET('/');
+        $this->assertSame($headers, $this->module->grabHttpHeaders());
+    }
+
     public function testSeeHeaders()
     {
         $response = new SymfonyResponse("", 200, [


### PR DESCRIPTION
From #114 

This adds functionality to return full headers and perform additional assertions on them, e.g. verifying substrings in headers.