### PR TITLE
Add support for jsonpath ^0.11.0 - for PHP 8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/codeception": "^5.0.8",
         "codeception/lib-xml": "^1.0",
         "justinrainbow/json-schema": "^5.2.9 || ^6",
-        "softcreatr/jsonpath": "^0.8 || ^0.9 || ^0.10"
+        "softcreatr/jsonpath": "^0.8 || ^0.9 || ^0.10 || ^0.11.0"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeception/codeception": "^5.0.8",
         "codeception/lib-xml": "^1.0",
         "justinrainbow/json-schema": "^5.2.9 || ^6",
-        "softcreatr/jsonpath": "^0.8 || ^0.9 || ^0.10 || ^0.11.0"
+        "softcreatr/jsonpath": "^0.8 || ^0.9 || ^0.10 || ^0.11"
     },
     "require-dev": {
         "ext-libxml": "*",


### PR DESCRIPTION
`softcreatr/jsonpath` version 0.10.0 and older do not support PHP 8.5. Recently in 0.11.0 support for PHP 8.5 was added in `softcreatr/jsonpath`.

See [SoftCreatR/JSONPath issue #82](https://github.com/SoftCreatR/JSONPath/issues/82)