### PR TITLE
Don't throw JsonException when logging requests with malformed payloads

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -692,7 +692,7 @@ EOF;
                 $files = [];
             } else {
                 $this->debugSection("Request",
-                    sprintf('%s %s ', $method, $url) . json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR)
+                    sprintf('%s %s ', $method, $url) . json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR)
                 );
                 $files = $this->formatFilesArray($files);
             }

--- a/tests/unit/Codeception/Module/RestTest.php
+++ b/tests/unit/Codeception/Module/RestTest.php
@@ -237,6 +237,22 @@ final class RestTest extends Unit
         $this->assertJson($request->getContent());
     }
 
+    public function testMalformedUtf8ArrayBodyDoesNotThrowDuringLogging()
+    {
+        // Intentionally badly-encoded payload (Windows-1250 bytes in a UTF-8 context).
+        // Building the request debug log must not throw a JsonException, and the request
+        // must still be dispatched with the raw bytes intact.
+        $invalidData = ['name' => iconv('utf-8', 'Windows-1250', 'michał')];
+
+        $this->module->sendPOST('/', $invalidData);
+
+        /** @var SymfonyRequest $request */
+        $request = $this->module->client->getRequest();
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame(http_build_query($invalidData), $request->getContent());
+    }
+
+
     /**
      * @dataProvider requestBodyAwareMethods
      */


### PR DESCRIPTION
# Problem

Since the move to Codeception 5, sending a request whose body contains malformed or non-UTF-8 data aborts with `[JsonException] Malformed UTF-8 characters, possibly incorrectly encoded`. This breaks negative-path API tests that intentionally send badly-encoded payloads — tests that worked under Codeception 4.

# Cause

In `REST::execute()` the request debug line is built with:

```php
json_encode($parameters, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR)
```

The `JSON_THROW_ON_ERROR` flag throws while merely formatting a console message; the actual request passes the raw `$parameters` to the connection module and never uses this encoded string. So a request that would otherwise be sent is aborted purely because its body can't be pretty-printed for the log.

# Fix

Replace `JSON_THROW_ON_ERROR` with `JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR` in that single debug-logging call.

The log stays readable (invalid bytes shown as U+FFFD, partial output on any other error) and can never block a request. The real `application/json` encoding path (`encodeApplicationJson`) is intentionally unchanged.
